### PR TITLE
Remove slashes from creation date

### DIFF
--- a/lib/PHPExif/Mapper/FFprobe.php
+++ b/lib/PHPExif/Mapper/FFprobe.php
@@ -122,6 +122,9 @@ class FFprobe implements MapperInterface
                     // only set value if QUICKTIME_DATE has not been used
                     if (!isset($mappedData[Exif::CREATION_DATE])) {
                         try {
+                            // Some cameras add a '/' between date and time
+                            // we need to remove it
+                            $value = str_replace('/', '', $value);
                             $value = new DateTime($value);
                         } catch (\Exception $e) {
                             continue 2;


### PR DESCRIPTION
Some old cameras put a slash between date and time (observed for videos) -> we remove it to obtain a valid creation time string.