### PR TITLE
fixes https://github.com/LycheeOrg/Lychee-laravel/issues/451

### DIFF
--- a/lib/PHPExif/Adapter/Native.php
+++ b/lib/PHPExif/Adapter/Native.php
@@ -208,8 +208,7 @@ class Native extends AdapterAbstract
         // Check data is a valid string
         foreach ($data as $k => $v) {
             // @codeCoverageIgnoreStart
-            if (!mb_check_encoding($v))
-            {
+            if (!mb_check_encoding($v)) {
                 $data[$k] = mb_convert_encoding($v, 'UTF-8');
             }
             // @codeCoverageIgnoreEnd

--- a/lib/PHPExif/Adapter/Native.php
+++ b/lib/PHPExif/Adapter/Native.php
@@ -205,6 +205,15 @@ class Native extends AdapterAbstract
             $data = array_merge($data, array(self::SECTION_IPTC => $xmpData));
         }
 
+        // Check data is a valid string
+        foreach ($data as $k => $v) {
+            // @codeCoverageIgnoreStart
+            if (!mb_check_encoding($v)) $data[$k] = mb_convert_encoding($v,'UTF-8');
+            // @codeCoverageIgnoreEnd
+        }
+        // var_dump($data);
+        // exit;
+
         // map the data:
         $mapper = $this->getMapper();
         $mappedData = $mapper->mapRawData($data);

--- a/lib/PHPExif/Adapter/Native.php
+++ b/lib/PHPExif/Adapter/Native.php
@@ -208,7 +208,10 @@ class Native extends AdapterAbstract
         // Check data is a valid string
         foreach ($data as $k => $v) {
             // @codeCoverageIgnoreStart
-            if (!mb_check_encoding($v)) $data[$k] = mb_convert_encoding($v,'UTF-8');
+            if (!mb_check_encoding($v))
+            {
+                $data[$k] = mb_convert_encoding($v, 'UTF-8');
+            }
             // @codeCoverageIgnoreEnd
         }
         // var_dump($data);


### PR DESCRIPTION
It appears there is no check for encoding before sending to the database in the case of Native users (i.e. without exiftool). We now add a conversion to utf-8.
