### PR TITLE
Convert Zulu timestamps from FFprobe to local

### DIFF
--- a/lib/PHPExif/Mapper/FFprobe.php
+++ b/lib/PHPExif/Mapper/FFprobe.php
@@ -13,6 +13,7 @@ namespace PHPExif\Mapper;
 
 use PHPExif\Exif;
 use DateTime;
+use DateTimeZone;
 use Exception;
 
 /**
@@ -126,6 +127,9 @@ class FFprobe implements MapperInterface
                             // we need to remove it
                             $value = str_replace('/', '', $value);
                             $value = new DateTime($value);
+                            if ($value->getTimezone()->getName() === 'Z') {
+                                $value->setTimezone(new DateTimeZone(date_default_timezone_get()));
+                            }
                         } catch (\Exception $e) {
                             continue 2;
                         }


### PR DESCRIPTION
See https://github.com/LycheeOrg/Lychee/issues/675

I'm not claiming that this is 100% correct or even 100% complete but I think it's a start. Basically, the issue is that at least Android phones store the timestamp in UTC. Lychee effectively strips the timezone info when storing the takestamp in the database so it then looks like local.

So this patch attempts to convert Zulu timestamps to server-local, which at least is user-configurable. Now that I think about it, perhaps this code shouldn't be in PHPExif (which returns correct information, with the time zone) but instead in Lychee itself. Only does PHPExif always return correct time zone info, including for data extracted from EXIF of still images?