### PR TITLE
Gracefully handle invalid time zone

### DIFF
--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -201,7 +201,11 @@ class Exiftool implements MapperInterface
                     if (!isset($mappedData[Exif::CREATION_DATE])) {
                         try {
                             if (isset($data['ExifIFD:OffsetTimeOriginal'])) {
-                                $timezone = new \DateTimeZone($data['ExifIFD:OffsetTimeOriginal']);
+                                try {
+                                    $timezone = new \DateTimeZone($data['ExifIFD:OffsetTimeOriginal']);
+                                } catch (\Exception $e) {
+                                    $timezone = null;
+                                }
                                 $value = new \DateTime($value, $timezone);
                             } else {
                                 $value = new \DateTime($value);

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -127,7 +127,11 @@ class ImageMagick implements MapperInterface
                 case self::DATETIMEORIGINAL:
                     try {
                         if (isset($data['exif:OffsetTimeOriginal'])) {
-                            $timezone = new \DateTimeZone($data['exif:OffsetTimeOriginal']);
+                            try {
+                                $timezone = new \DateTimeZone($data['exif:OffsetTimeOriginal']);
+                            } catch (\Exception $e) {
+                                $timezone = null;
+                            }
                             $value = new \DateTime($value, $timezone);
                         } else {
                             $value = new \DateTime($value);

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -178,7 +178,11 @@ class Native implements MapperInterface
                     // Check if OffsetTimeOriginal (0x9011) is available
                     try {
                         if (isset($data['UndefinedTag:0x9011'])) {
-                            $timezone = new \DateTimeZone($data['UndefinedTag:0x9011']);
+                            try {
+                                $timezone = new \DateTimeZone($data['UndefinedTag:0x9011']);
+                            } catch (\Exception $e) {
+                                $timezone = null;
+                            }
                             $value = new \DateTime($value, $timezone);
                         } else {
                             $value = new \DateTime($value);

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -242,6 +242,27 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\Exiftool::mapRawData
      */
+    public function testMapRawDataCorrectlyIgnoresIncorrectTimeZone()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            'ExifIFD:OffsetTimeOriginal' => '   :  ',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $result = reset($mapped);
+        $this->assertInstanceOf('\\DateTime', $result);
+        $this->assertEquals(
+            '2015:04:01 12:11:09',
+            $result->format('Y:m:d H:i:s')
+        );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     */
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
         $rawData = array(

--- a/tests/PHPExif/Mapper/ImageMagickMapperTest.php
+++ b/tests/PHPExif/Mapper/ImageMagickMapperTest.php
@@ -275,6 +275,27 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\ImageMagick::mapRawData
      */
+    public function testMapRawDataCorrectlyIgnoresIncorrectTimeZone()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            'exif:OffsetTimeOriginal' => '   :  ',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $result = reset($mapped);
+        $this->assertInstanceOf('\\DateTime', $result);
+        $this->assertEquals(
+            '2015:04:01 12:11:09',
+            $result->format('Y:m:d H:i:s')
+        );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     */
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
         $rawData = array(

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -169,6 +169,27 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\Native::mapRawData
      */
+    public function testMapRawDataCorrectlyIgnoresIncorrectTimeZone()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\Native::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            'UndefinedTag:0x9011' => '   :  ',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $result = reset($mapped);
+        $this->assertInstanceOf('\\DateTime', $result);
+        $this->assertEquals(
+            '2015:04:01 12:11:09',
+            $result->format('Y:m:d H:i:s')
+        );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
         $rawData = array(


### PR DESCRIPTION
My Olympus OM-D E-M5 Mark III provides `OffsetTimeOriginal` in EXIF but with an empty value (well, not quite empty: `   :  `). I know, ugly, but what can you do... So DateTimeZone object creation fails and as a result we fail to extract the creation date of JPEG files.

This patch makes the failure of DateTimeZone creation non-fatal.