### PR TITLE
Lensid

### DIFF
--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -58,6 +58,7 @@ class Exiftool implements MapperInterface
     const DESCRIPTION              = 'ExifIFD:ImageDescription';
     const MAKE                     = 'IFD0:Make';
     const LENS                     = 'ExifIFD:LensModel';
+    const LENS_ID                  = 'Composite:LensID';
     const SUBJECT                  = 'XMP-dc:Subject';
     const CONTENTIDENTIFIER        = 'Apple:ContentIdentifier';
     const MICROVIDEOOFFSET         = 'XMP-GCamera:MicroVideoOffset';
@@ -123,6 +124,7 @@ class Exiftool implements MapperInterface
         self::MAKE                     => Exif::MAKE,
         self::IMGDIRECTION             => Exif::IMGDIRECTION,
         self::LENS                     => Exif::LENS,
+        self::LENS_ID                  => Exif::LENS,
         self::DESCRIPTION              => Exif::DESCRIPTION,
         self::SUBJECT                  => Exif::KEYWORDS,
         self::CONTENTIDENTIFIER        => Exif::CONTENTIDENTIFIER,
@@ -317,6 +319,12 @@ class Exiftool implements MapperInterface
                         // @codeCoverageIgnoreEnd
                     }
 
+                    continue 2;
+                    break;
+                case self::LENS_ID:
+                    if (empty($mappedData[Exif::LENS])) {
+                        $mappedData[Exif::LENS] = $value;
+                    }
                     continue 2;
                     break;
             }

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -238,14 +238,16 @@ class Native implements MapperInterface
                     $value = $this->normalizeComponent($value);
                     break;
                 case self::LENS_LR:
-                    if (!(empty($mappedData[Exif::LENS]))) {
+                    if (empty($mappedData[Exif::LENS])) {
                         $mappedData[Exif::LENS] = $value;
                     }
+                    continue 2;
                     break;
                 case self::LENS_TYPE:
-                    if (!(empty($mappedData[Exif::LENS]))) {
+                    if (empty($mappedData[Exif::LENS])) {
                         $mappedData[Exif::LENS] = $value;
                     }
+                    continue 2;
                     break;
             }
 

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -865,7 +865,7 @@ class ExifTest extends \PHPUnit\Framework\TestCase
             // find all Getter methods on the results and compare its output
             foreach ($methods as $method) {
                 $name = $method->getName();
-                if (strpos($name, 'get') !== 0 || $name == 'getRawData' || $name == 'getData' || $name == 'getColorSpace') {
+                if (strpos($name, 'get') !== 0 || $name == 'getRawData' || $name == 'getData' || $name == 'getColorSpace' || ($name == 'getLens' && $file == PHPEXIF_TEST_ROOT . '/files/dsc_5794.jpg')) {
                     continue;
                 }
                 $this->assertEquals(

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -598,4 +598,52 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
     	          $this->assertEquals($key, reset($result));
             }
         }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     */
+    public function testMapRawDataCorrectlyLensData()
+    {
+        $data = array (
+            array(
+                \PHPExif\Mapper\Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
+            ),
+            array(
+                \PHPExif\Mapper\Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                \PHPExif\Mapper\Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
+            ),
+            array(
+                \PHPExif\Mapper\Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                \PHPExif\Mapper\Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
+          )
+        );
+
+        foreach ($data as $key => $rawData) {
+            $mapped = $this->mapper->mapRawData($rawData);
+
+            $this->assertEquals(
+                'LEICA DG 12-60/F2.8-4.0',
+                reset($mapped)
+            );
+        }
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     */
+    public function testMapRawDataCorrectlyLensData2()
+    {
+        $rawData = array (
+            \PHPExif\Mapper\Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(
+            'LUMIX G VARIO 12-32/F3.5-5.6',
+            reset($mapped)
+        );
+    }
 }

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -70,6 +70,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
         unset($map[\PHPExif\Mapper\Exiftool::SUBLOCATION]);
         unset($map[\PHPExif\Mapper\Exiftool::STATE]);
         unset($map[\PHPExif\Mapper\Exiftool::COUNTRY]);
+        unset($map[\PHPExif\Mapper\Exiftool::LENS_ID]);
 
         // create raw data
         $keys = array_keys($map);

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -425,4 +425,64 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 	          $this->assertEquals($key, reset($result));
         }
     }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
+    public function testMapRawDataCorrectlyLensData()
+    {
+        $data = array (
+            array(
+                \PHPExif\Mapper\Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
+            ),
+            array(
+                \PHPExif\Mapper\Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                \PHPExif\Mapper\Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                \PHPExif\Mapper\Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
+            ),
+            array(
+                \PHPExif\Mapper\Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                \PHPExif\Mapper\Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
+            ),
+            array(
+                \PHPExif\Mapper\Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                \PHPExif\Mapper\Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
+            )
+        );
+
+        foreach ($data as $key => $rawData) {
+            $mapped = $this->mapper->mapRawData($rawData);
+
+            $this->assertEquals(
+                'LEICA DG 12-60/F2.8-4.0',
+                reset($mapped)
+            );
+        }
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
+    public function testMapRawDataCorrectlyLensData2()
+    {
+        $data = array (
+            array(
+                \PHPExif\Mapper\Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
+            ),
+            array(
+                \PHPExif\Mapper\Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
+            )
+        );
+
+        foreach ($data as $key => $rawData) {
+            $mapped = $this->mapper->mapRawData($rawData);
+
+            $this->assertEquals(
+                'LUMIX G VARIO 12-32/F3.5-5.6',
+                reset($mapped)
+            );
+        }
+    }
 }


### PR DESCRIPTION
My Panasonic GM1 does not provide the `LensModel` EXIF tag but instead uses what exiftool says is Panasonic-specific `LensType`. Thankfully exiftool also provides a composite `LensID` that should be portable. This patch adds the `Composite:LensID` as a fallback in case `ExifIFD:LensModel` is not available.

White working on this I noticed that the existing fallback logic in the native mapper was wrong so I fixed that as well.