### PR TITLE
Trim whitespace characters from values

### DIFF
--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -171,7 +171,9 @@ class Native implements MapperInterface
             }
 
             $key = $this->map[$field];
-            $value = trim($value);
+            if (is_string($value)) {
+                $value = trim($value);
+            }
 
             // manipulate the value if necessary
             switch ($field) {

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -171,6 +171,7 @@ class Native implements MapperInterface
             }
 
             $key = $this->map[$field];
+            $value = trim($value);
 
             // manipulate the value if necessary
             switch ($field) {


### PR DESCRIPTION
This actually fixes a bug I encountered with my Panasonic GM1. It fills the EXIF title field in JPEG files with a series of `\u{0000}`, and that then becomes the title in Lychee. We do check if the string is not empty but that test fails because, well, a series of `\u{0000}`s is not an empty string...

As a side effect, this also gets rid of ugly trailing spaces in some fields such as the lens name.

The change is pretty broad but I can't think of any problems it could cause. If needed though, we can narrow it down to a subset of fields, of course.