### PR TITLE
Merge arrays recursively

### DIFF
--- a/lib/PHPExif/Adapter/FFprobe.php
+++ b/lib/PHPExif/Adapter/FFprobe.php
@@ -111,7 +111,7 @@ class FFprobe extends AdapterAbstract
         $data_filesize = filesize($file);
 
         $additional_data = array('MimeType' => $mimeType, 'filesize' => $data_filesize, 'filename' => $data_filename);
-        $data = array_merge($stream, $format, $additional_data);
+        $data = array_replace_recursive($stream, $format, $additional_data);
 
         // Force UTF8 encoding
         $data = $this->convertToUTF8($data);


### PR DESCRIPTION
`$stream` and `$format` are two-dimensional and both contain a `tags` subarray. As the code was, `tags` from `$stream` would get lost during merge so the code in the Mapper to swap width and height for video shot in portrait wouldn't trigger. The merge needs to be done recursively, using the `replace` variant so that identical fields (such as `creation_date`) don't get turned into arrays.