### PR TITLE
Map XMP-dc title and description properties

### DIFF
--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -49,6 +49,7 @@ class Exiftool implements MapperInterface
     const SOFTWARE                 = 'IFD0:Software';
     const SOURCE                   = 'IPTC:Source';
     const TITLE                    = 'IPTC:ObjectName';
+    const TITLE_XMP                = 'XMP-dc:Title';
     const XRESOLUTION              = 'IFD0:XResolution';
     const YRESOLUTION              = 'IFD0:YResolution';
     const GPSLATITUDE              = 'GPS:GPSLatitude';
@@ -56,6 +57,7 @@ class Exiftool implements MapperInterface
     const GPSALTITUDE              = 'GPS:GPSAltitude';
     const IMGDIRECTION             = 'GPS:GPSImgDirection';
     const DESCRIPTION              = 'ExifIFD:ImageDescription';
+    const DESCRIPTION_XMP          = 'XMP-dc:Description';
     const MAKE                     = 'IFD0:Make';
     const LENS                     = 'ExifIFD:LensModel';
     const LENS_ID                  = 'Composite:LensID';
@@ -104,6 +106,7 @@ class Exiftool implements MapperInterface
         self::ARTIST                   => Exif::AUTHOR,
         self::MODEL                    => Exif::CAMERA,
         self::CAPTION                  => Exif::CAPTION,
+        self::DESCRIPTION_XMP          => Exif::CAPTION,
         self::COLORSPACE               => Exif::COLORSPACE,
         self::COPYRIGHT                => Exif::COPYRIGHT,
         self::DATETIMEORIGINAL         => Exif::CREATION_DATE,
@@ -124,6 +127,7 @@ class Exiftool implements MapperInterface
         self::SOFTWARE                 => Exif::SOFTWARE,
         self::SOURCE                   => Exif::SOURCE,
         self::TITLE                    => Exif::TITLE,
+        self::TITLE_XMP                => Exif::TITLE,
         self::YRESOLUTION              => Exif::VERTICAL_RESOLUTION,
         self::IMAGEWIDTH               => Exif::WIDTH,
         self::CAPTIONABSTRACT          => Exif::CAPTION,

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -50,6 +50,8 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
         unset($map[\PHPExif\Mapper\Exiftool::GPSLATITUDE]);
         unset($map[\PHPExif\Mapper\Exiftool::GPSLONGITUDE]);
         unset($map[\PHPExif\Mapper\Exiftool::CAPTION]);
+        unset($map[\PHPExif\Mapper\Exiftool::TITLE]);
+        unset($map[\PHPExif\Mapper\Exiftool::DESCRIPTION_XMP]);
         unset($map[\PHPExif\Mapper\Exiftool::CONTENTIDENTIFIER]);
         unset($map[\PHPExif\Mapper\Exiftool::KEYWORDS]);
         unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL]);


### PR DESCRIPTION
The XMP-dc:title and XMP-dc:description map to the core values
of title (objectname)[0] and caption [1] and some applications
like darktable only fill XMP fields.

Therefore allow the Exif-fields to be filled from them as well.

[0] https://iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#title
[1] https://iptc.org/std/photometadata/specification/IPTC-PhotoMetadata#description

Signed-off-by: Heiko Stuebner <heiko@sntech.de>