### PR TITLE
Copy over MIME tweaks from ffprobe adapter

### DIFF
--- a/lib/PHPExif/Adapter/Native.php
+++ b/lib/PHPExif/Adapter/Native.php
@@ -180,7 +180,18 @@ class Native extends AdapterAbstract
     {
         $mimeType = mime_content_type($file);
 
+        if ($mimeType === 'image/x-tga') {
+            // @codeCoverageIgnoreStart
+            $mimeType = 'video/mpeg';
+            // @codeCoverageIgnoreEnd
+        }
 
+        if ($mimeType === 'application/octet-stream' &&
+            in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), ['mp4', 'mp4v', 'mpg4'])) {
+            // @codeCoverageIgnoreStart
+            $mimeType = 'video/mp4';
+            // @codeCoverageIgnoreEnd
+        }
 
         // Photo
         $sections   = $this->getRequiredSections();


### PR DESCRIPTION
The video mime tweaks made to the ffprobe adapter should also be used by native, in case ffprobe is not available.