### PR TITLE
Compensate for slightly dodgy EXIF data

### DIFF
--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -339,7 +339,7 @@ class Native implements MapperInterface
             return (float) $parts[0];
         }
         // case part[1] is 0, div by 0 is forbidden.
-        if ($parts[1] == 0) {
+        if ($parts[1] == 0 || !is_numeric($parts[0]) || !is_numeric($parts[1])) {
             return (float) 0;
         }
         return (float) $parts[0] / $parts[1];


### PR DESCRIPTION
I have some very old photos from a very early digital camera. Apparently it has some dodgy EXIF data that results in an error on line 345, "A non well formed numeric value encountered."
This allows that dodgy data to gracefully fail and carry on.