### PR TITLE
Gracefully handle null entries in the array

### DIFF
--- a/lib/PHPExif/Adapter/AdapterAbstract.php
+++ b/lib/PHPExif/Adapter/AdapterAbstract.php
@@ -120,11 +120,11 @@ abstract class AdapterAbstract implements AdapterInterface
      * Encodes an array of strings into UTF8
      *
      * @param array|string $data
-     * @return array
+     * @return array|string|null
      */
     // @codeCoverageIgnoreStart
     // this is fine because we use it directly in our tests for Exiftool and Native
-    public function convertToUTF8($data) : array|string
+    public function convertToUTF8($data) : array|string|null
     {
         if (is_array($data)) {
             foreach ($data as $k => $v) {


### PR DESCRIPTION
First victim of the recent type tightening: with the native adapter, I saw a failure for a photo with a `UserComment` tag equal to `null`.