### PR TITLE
Fix 1367

### DIFF
--- a/lib/PHPExif/Adapter/ImageMagick.php
+++ b/lib/PHPExif/Adapter/ImageMagick.php
@@ -48,7 +48,10 @@ class ImageMagick extends AdapterAbstract
         $data_filename = basename($file);
         $data_filesize = filesize($file);
         $mimeType = mime_content_type($file);
-        $additional_data = array('MimeType' => $mimeType, 'filesize' => $data_filesize, 'filename' => $data_filename);
+        $data_width = $im->getImageWidth();
+        $data_height = $im->getImageHeight();
+        $additional_data = array('MimeType' => $mimeType, 'filesize' => $data_filesize, 'filename' => $data_filename, 'width' => $data_width, 'height' => $data_height);
+
         $data = array_merge($data_exif, $additional_data);
 
         // map the data:

--- a/lib/PHPExif/Adapter/ImageMagick.php
+++ b/lib/PHPExif/Adapter/ImageMagick.php
@@ -50,7 +50,12 @@ class ImageMagick extends AdapterAbstract
         $mimeType = mime_content_type($file);
         $data_width = $im->getImageWidth();
         $data_height = $im->getImageHeight();
-        $additional_data = array('MimeType' => $mimeType, 'filesize' => $data_filesize, 'filename' => $data_filename, 'width' => $data_width, 'height' => $data_height);
+        $additional_data = array(
+            'MimeType' => $mimeType,
+            'filesize' => $data_filesize,
+            'filename' => $data_filename,
+            'width' => $data_width,
+            'height' => $data_height);
 
         $data = array_merge($data_exif, $additional_data);
 

--- a/lib/PHPExif/Adapter/ImageMagick.php
+++ b/lib/PHPExif/Adapter/ImageMagick.php
@@ -50,12 +50,13 @@ class ImageMagick extends AdapterAbstract
         $mimeType = mime_content_type($file);
         $data_width = $im->getImageWidth();
         $data_height = $im->getImageHeight();
-        $additional_data = array(
+        $additional_data = [
             'MimeType' => $mimeType,
             'filesize' => $data_filesize,
             'filename' => $data_filename,
             'width' => $data_width,
-            'height' => $data_height);
+            'height' => $data_height
+        ];
 
         $data = array_merge($data_exif, $additional_data);
 

--- a/lib/PHPExif/Exif.php
+++ b/lib/PHPExif/Exif.php
@@ -969,10 +969,10 @@ class Exif
     /**
      * Sets the altitude value
      *
-     * @param float|false $value
+     * @param float $value
      * @return Exif
      */
-    public function setLongitude(float|false $value) : Exif
+    public function setLongitude(float $value) : Exif
     {
         $this->data[self::LONGITUDE] = $value;
 
@@ -996,10 +996,10 @@ class Exif
     /**
      * Sets the latitude value
      *
-     * @param float|false $value
+     * @param float $value
      * @return Exif
      */
-    public function setLatitude(float|false $value) : Exif
+    public function setLatitude(float $value) : Exif
     {
         $this->data[self::LATITUDE] = $value;
 

--- a/lib/PHPExif/Exif.php
+++ b/lib/PHPExif/Exif.php
@@ -793,10 +793,10 @@ class Exif
     /**
      * Sets the filesize
      *
-     * @param string $value
+     * @param int $value
      * @return Exif
      */
-    public function setFileSize(string $value) : Exif
+    public function setFileSize(int $value) : Exif
     {
         $this->data[self::FILESIZE] = $value;
 
@@ -942,10 +942,10 @@ class Exif
     /**
      * Sets the altitude value
      *
-     * @param string $value
+     * @param float $value
      * @return Exif
      */
-    public function setAltitude(string $value) : Exif
+    public function setAltitude(float $value) : Exif
     {
         $this->data[self::ALTITUDE] = $value;
 
@@ -969,10 +969,10 @@ class Exif
     /**
      * Sets the altitude value
      *
-     * @param string $value
+     * @param float|false $value
      * @return Exif
      */
-    public function setLongitude(string $value) : Exif
+    public function setLongitude(float|false $value) : Exif
     {
         $this->data[self::LONGITUDE] = $value;
 
@@ -996,10 +996,10 @@ class Exif
     /**
      * Sets the latitude value
      *
-     * @param string $value
+     * @param float|false $value
      * @return Exif
      */
-    public function setLatitude(string $value) : Exif
+    public function setLatitude(float|false $value) : Exif
     {
         $this->data[self::LATITUDE] = $value;
 
@@ -1023,10 +1023,10 @@ class Exif
     /**
      * Sets the imgDirection value
      *
-     * @param string $value
+     * @param float $value
      * @return Exif
      */
-    public function setImgDirection(string $value) : Exif
+    public function setImgDirection(float $value) : Exif
     {
         $this->data[self::IMGDIRECTION] = $value;
 

--- a/lib/PHPExif/Mapper/FFprobe.php
+++ b/lib/PHPExif/Mapper/FFprobe.php
@@ -149,6 +149,9 @@ class FFprobe implements MapperInterface
                     break;
                 case self::FRAMERATE:
                     $value = $this->normalizeComponent($value);
+                    if ($value === false) {
+                        continue 2;
+                    }
                     break;
                 case self::GPSLATITUDE:
                 case self::GPSLONGITUDE:
@@ -168,7 +171,6 @@ class FFprobe implements MapperInterface
                     $mappedData[Exif::LATITUDE]  = $location_data['latitude'];
                     $mappedData[Exif::LONGITUDE] = $location_data['longitude'];
                     $mappedData[Exif::ALTITUDE]  = $location_data['altitude'];
-                    //$value = $this->normalizeComponent($value);
                     continue 2;
             }
 
@@ -179,8 +181,6 @@ class FFprobe implements MapperInterface
         // add GPS coordinates, if available
         if ((isset($mappedData[Exif::LATITUDE])) && (isset($mappedData[Exif::LONGITUDE]))) {
             $mappedData[Exif::GPS] = sprintf('%s,%s', $mappedData[Exif::LATITUDE], $mappedData[Exif::LONGITUDE]);
-        } else {
-            unset($mappedData[Exif::GPS]);
         }
 
         // Swap width and height if needed
@@ -236,9 +236,9 @@ class FFprobe implements MapperInterface
      * Normalize component
      *
      * @param string $rational
-     * @return float
+     * @return float|false
      */
-    protected function normalizeComponent(string $rational) : float
+    protected function normalizeComponent(string $rational) : float|false
     {
         $parts = explode('/', $rational, 2);
         if (count($parts) === 1) {
@@ -247,7 +247,7 @@ class FFprobe implements MapperInterface
         // case part[1] is 0, div by 0 is forbidden.
         // Catch case of one entry not being numeric
         if ($parts[1] === '0' || !is_numeric($parts[0]) || !is_numeric($parts[1])) {
-            return (float) 0;
+            return false;
         }
         return (float) $parts[0] / $parts[1];
     }

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -119,7 +119,11 @@ class ImageMagick implements MapperInterface
             // manipulate the value if necessary
             switch ($field) {
                 case self::APERTURE:
-                    $value = sprintf('f/%01.1f', $this->normalizeComponent($value));
+                    $value = $this->normalizeComponent($value);
+                    if ($value === false) {
+                        continue 2;
+                    }
+                    $value = sprintf('f/%01.1f', $value);
                     break;
                 case self::CREATION_DATE:
                     if (!isset($mappedData[Exif::CREATION_DATE])
@@ -154,6 +158,9 @@ class ImageMagick implements MapperInterface
                     break;
                 case self::EXPOSURETIME:
                     $value = $this->normalizeComponent($value);
+                    if ($value === false) {
+                        continue 2;
+                    }
                     // Based on the source code of Exiftool (PrintExposureTime subroutine):
                     // http://cpansearch.perl.org/src/EXIFTOOL/Image-ExifTool-9.90/lib/Image/ExifTool/Exif.pm
                     if ($value < 0.25001 && $value > 0) {
@@ -169,6 +176,9 @@ class ImageMagick implements MapperInterface
                         $value = reset($focalLengthParts);
                     }
                     $value = $this->normalizeComponent($value);
+                    if ($value === false) {
+                        continue 2;
+                    }
                     break;
                 case self::ISO:
                     $value = preg_split('/([\s,]+)/', $value)[0];
@@ -177,36 +187,43 @@ class ImageMagick implements MapperInterface
                     $latitudeRef = !array_key_exists('exif:GPSLatitudeRef', $data) ?
                         'N' : $data['exif:GPSLatitudeRef'][0];
                     $value = $this->extractGPSCoordinates($value);
-                    if ($value !== false) {
-                        $value = (strtoupper($latitudeRef) === 'S' ? -1.0 : 1.0) * $value;
+                    if ($value === false) {
+                        continue 2;
                     }
-
+                    $value *= strtoupper($latitudeRef) === 'S' ? -1 : 1;
                     break;
                 case self::GPSLONGITUDE:
                     $longitudeRef = !array_key_exists('exif:GPSLongitudeRef', $data) ?
                         'E' : $data['exif:GPSLongitudeRef'][0];
                     $value  = $this->extractGPSCoordinates($value);
-                    if ($value !== false) {
-                        $value  = (strtoupper($longitudeRef) === 'W' ? -1 : 1) * $value;
+                    if ($value === false) {
+                        continue 2;
                     }
-
+                    $value *= strtoupper($longitudeRef) === 'W' ? -1 : 1;
                     break;
                 case self::GPSALTITUDE:
                     $flip = 1;
                     if (array_key_exists('exif:GPSAltitudeRef', $data)) {
                         $flip = ($data['exif:GPSAltitudeRef'] === '1') ? -1 : 1;
                     }
-                    $value = $flip * $this->normalizeComponent($value);
+                    $value = $this->normalizeComponent($value);
+                    if ($value === false) {
+                        continue 2;
+                    }
+                    $value *= $flip;
                     break;
                 case self::IMAGEHEIGHT_PNG:
                 case self::IMAGEWIDTH_PNG:
-                    $value_splitted = explode(",", $value);
+                    $value_split = explode(",", $value);
 
-                    $mappedData[Exif::WIDTH]  = intval($value_splitted[0]);
-                    $mappedData[Exif::HEIGHT] = intval($value_splitted[1]);
+                    $mappedData[Exif::WIDTH]  = intval($value_split[0]);
+                    $mappedData[Exif::HEIGHT] = intval($value_split[1]);
                     continue 2;
                 case self::IMGDIRECTION:
                     $value = $this->normalizeComponent($value);
+                    if ($value === false) {
+                        continue 2;
+                    }
                     break;
             }
             // set end result
@@ -215,13 +232,7 @@ class ImageMagick implements MapperInterface
 
         // add GPS coordinates, if available
         if ((isset($mappedData[Exif::LATITUDE])) && (isset($mappedData[Exif::LONGITUDE]))) {
-            if (($mappedData[Exif::LATITUDE]!==false) && $mappedData[Exif::LONGITUDE]!==false) {
-                $mappedData[Exif::GPS] = sprintf('%s,%s', $mappedData[Exif::LATITUDE], $mappedData[Exif::LONGITUDE]);
-            } else {
-                $mappedData[Exif::GPS] = false;
-            }
-        } else {
-            unset($mappedData[Exif::GPS]);
+            $mappedData[Exif::GPS] = sprintf('%s,%s', $mappedData[Exif::LATITUDE], $mappedData[Exif::LONGITUDE]);
         }
         return $mappedData;
     }
@@ -244,6 +255,9 @@ class ImageMagick implements MapperInterface
             $degree = floatval($this->normalizeComponent($matches[1]));
             $minutes = floatval($this->normalizeComponent($matches[2]));
             $seconds = floatval($this->normalizeComponent($matches[3]));
+            if ($degree === false || $minutes === false || $seconds === false) {
+                return false;
+            }
             return $degree + $minutes / 60 + $seconds / 3600;
         }
     }
@@ -252,9 +266,9 @@ class ImageMagick implements MapperInterface
      * Normalize component
      *
      * @param string $rational
-     * @return float
+     * @return float|false
      */
-    protected function normalizeComponent(string $rational) : float
+    protected function normalizeComponent(string $rational) : float|false
     {
         $parts = explode('/', $rational, 2);
         if (count($parts) === 1) {
@@ -263,7 +277,7 @@ class ImageMagick implements MapperInterface
         // case part[1] is 0, div by 0 is forbidden.
         // Catch case of one entry not being numeric
         if ($parts[1] === '0' || !is_numeric($parts[0]) || !is_numeric($parts[1])) {
-            return (float) 0;
+            return false;
         }
         return (float) $parts[0] / $parts[1];
     }

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -252,13 +252,13 @@ class ImageMagick implements MapperInterface
             if (preg_match($m, $coordinates, $matches) === 0) {
                 return false;
             }
-            $degree = floatval($this->normalizeComponent($matches[1]));
-            $minutes = floatval($this->normalizeComponent($matches[2]));
-            $seconds = floatval($this->normalizeComponent($matches[3]));
-            if ($degree === false || $minutes === false || $seconds === false) {
+            $degrees = $this->normalizeComponent($matches[1]);
+            $minutes = $this->normalizeComponent($matches[2]);
+            $seconds = $this->normalizeComponent($matches[3]);
+            if ($degrees === false || $minutes === false || $seconds === false) {
                 return false;
             }
-            return $degree + $minutes / 60 + $seconds / 3600;
+            return $degrees + $minutes / 60 + $seconds / 3600;
         }
     }
 

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -175,8 +175,6 @@ class ImageMagick implements MapperInterface
                     $value = $this->extractGPSCoordinates($value);
                     if ($value !== false) {
                         $value = (strtoupper($latitudeRef) === 'S' ? -1.0 : 1.0) * $value;
-                    } else {
-                        $value = false;
                     }
 
                     break;
@@ -235,7 +233,7 @@ class ImageMagick implements MapperInterface
         if (is_numeric($coordinates) === true) {
             return ((float) $coordinates);
         } else {
-            $m = '!^([1-9][0-9]*\/[1-9][0-9]*), ([1-9][0-9]*\/[1-9][0-9]*), ([1-9][0-9]*\/[1-9][0-9]*)!';
+            $m = '!^([0-9]+\/[1-9][0-9]*), ([0-9]+\/[1-9][0-9]*), ([0-9]+\/[1-9][0-9]*)!';
             if (preg_match($m, $coordinates, $matches) === 0) {
                 return false;
             }

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -43,8 +43,10 @@ class ImageMagick implements MapperInterface
     const GPSALTITUDE              = 'exif:GPSAltitude';
     const IMAGEHEIGHT              = 'exif:PixelYDimension';
     const IMAGEHEIGHT_PNG          = 'png:IHDR.width,height';
+    const HEIGHT                   = 'height';
     const IMAGEWIDTH               = 'exif:PixelXDimension';
     const IMAGEWIDTH_PNG           = 'png:IHDR.width,height';
+    const WIDTH                    = 'width';
     const IMGDIRECTION             = 'exif:GPSImgDirection';
     const ISO                      = 'exif:PhotographicSensitivity';
     const LENS                     = 'exif:LensModel';
@@ -78,8 +80,10 @@ class ImageMagick implements MapperInterface
         self::IMGDIRECTION             => Exif::IMGDIRECTION,
         self::IMAGEHEIGHT              => Exif::HEIGHT,
         self::IMAGEHEIGHT_PNG          => Exif::HEIGHT,
+        self::HEIGHT                   => Exif::HEIGHT,
         self::IMAGEWIDTH               => Exif::WIDTH,
         self::IMAGEWIDTH_PNG           => Exif::WIDTH,
+        self::WIDTH                    => Exif::WIDTH,
         self::ISO                      => Exif::ISO,
         self::LENS                     => Exif::LENS,
         self::MAKE                     => Exif::MAKE,

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -793,6 +793,15 @@ class ExifTest extends \PHPUnit\Framework\TestCase
             $setter = 'set' . ucfirst($value);
 
             switch ($value) {
+                case 'altitude':
+                case 'imgDirection':
+                case 'latitude':
+                case 'longitude':
+                    $coord = 1.2345;
+                    $this->exif->$setter($coord);
+                    $propertyValue = $reflProp->getValue($this->exif);
+                    $this->assertEquals($coord, $propertyValue[$value]);
+                    break;
                 case 'creationdate':
                     $now = new \DateTime();
                     $this->exif->$setter($now);

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -808,6 +808,12 @@ class ExifTest extends \PHPUnit\Framework\TestCase
                     $propertyValue = $reflProp->getValue($this->exif);
                     $this->assertSame($now, $propertyValue[$value]);
                     break;
+                case 'FileSize':
+                    $size = 10123456;
+                    $this->exif->$setter($size);
+                    $propertyValue = $reflProp->getValue($this->exif);
+                    $this->assertEquals($size, $propertyValue[$value]);
+                    break;
                 case 'gps':
                     $coords = '40.333452380556,-20.167314813889';
                     $setter = 'setGPS';

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -357,13 +357,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-        $expected_gps = false;
-        $expected_lat = false;
-        $expected_lon = false;
-        $this->assertCount(3, $result);
-        $this->assertEquals($expected_gps, $result['gps']);
-        $this->assertEquals($expected_lat, $result['latitude']);
-        $this->assertEquals($expected_lon, $result['longitude']);
+        $this->assertCount(0, $result);
     }
 
     /**

--- a/tests/PHPExif/Mapper/ImageMagickMapperTest.php
+++ b/tests/PHPExif/Mapper/ImageMagickMapperTest.php
@@ -50,7 +50,8 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
         unset($map[\PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL]);
         unset($map[\PHPExif\Mapper\ImageMagick::ISO]);
         unset($map[\PHPExif\Mapper\ImageMagick::LENS]);
-        unset($map[\PHPExif\Mapper\ImageMagick::IMAGEWIDTH]);
+        unset($map[\PHPExif\Mapper\ImageMagick::WIDTH]);
+        unset($map[\PHPExif\Mapper\ImageMagick::HEIGHT]);
         unset($map[\PHPExif\Mapper\ImageMagick::IMAGEHEIGHT_PNG]);
         unset($map[\PHPExif\Mapper\ImageMagick::IMAGEWIDTH_PNG]);
         unset($map[\PHPExif\Mapper\ImageMagick::CREATION_DATE]);
@@ -61,11 +62,10 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
         $values = array_pad($values, count($keys), 'foo');
         $rawData = array_combine($keys, $values);
 
-
         $mapped = $this->mapper->mapRawData($rawData);
 
         $i = 0;
-	      foreach ($mapped as $key => $value) {
+        foreach ($mapped as $key => $value) {
             $this->assertEquals($map[$keys[$i]], $key);
             $i++;
         }
@@ -366,13 +366,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
                 'GPS:GPSLongitudeRef'                  => 'W',
             )
         );
-        $expected_gps = false;
-        $expected_lat = false;
-        $expected_lon = false;
-        $this->assertCount(3, $result);
-        $this->assertEquals($expected_gps, $result['gps']);
-        $this->assertEquals($expected_lat, $result['latitude']);
-        $this->assertEquals($expected_lon, $result['longitude']);
+        $this->assertCount(0, $result);
     }
 
     /**
@@ -463,7 +457,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
                 'exif:GPSAltitudeRef'                   => '0',
             )
         );
-	$expected = 122.053;
+        $expected = 122.053;
         $this->assertEquals($expected, reset($result));
     }
 
@@ -503,8 +497,8 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
             );
 
             foreach ($expected as $key => $value) {
-    		        $result = $this->mapper->mapRawData($value);
-    	          $this->assertEquals($key, reset($result));
+                $result = $this->mapper->mapRawData($value);
+                $this->assertEquals($key, reset($result));
             }
         }
 

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -326,9 +326,9 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
                 'GPSLongitudeRef' => 'W',
             ),
             '0,-0' => array(
-                'GPSLatitude'     => array('0/0', '0/0', '0/0'),
+                'GPSLatitude'     => array('0/1', '0/1', '0/1'),
                 'GPSLatitudeRef'  => 'N',
-                'GPSLongitude'    => array('0/0', '0/0', '0/0'),
+                'GPSLongitude'    => array('0/1', '0/1', '0/1'),
                 'GPSLongitudeRef' => 'W',
             ),
             '71.706936,-42.604303' => array(
@@ -340,8 +340,8 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
         );
 
         foreach ($expected as $key => $value) {
-		        $result = $this->mapper->mapRawData($value);
-	          $this->assertEquals($key, $result[\PHPExif\Exif::GPS]);
+            $result = $this->mapper->mapRawData($value);
+            $this->assertEquals($key, $result[\PHPExif\Exif::GPS]);
         }
     }
 
@@ -363,8 +363,8 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
         );
 
         foreach ($expected as $key => $value) {
-		        $result = $this->mapper->mapRawData($value);
-	          $this->assertEquals($key, $result[\PHPExif\Exif::ALTITUDE]);
+            $result = $this->mapper->mapRawData($value);
+            $this->assertEquals($key, $result[\PHPExif\Exif::ALTITUDE]);
         }
     }
 
@@ -449,8 +449,8 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
         );
 
         foreach ($expected as $key => $value) {
-		        $result = $this->mapper->mapRawData($value);
-	          $this->assertEquals($key, reset($result));
+            $result = $this->mapper->mapRawData($value);
+            $this->assertEquals($key, reset($result));
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee/issues/1367

The fix itself is a one-liner: the regular expression in Imagick mapper was not allowing a `0` for degrees/minutes/seconds. However, the way it was failing (with a type mismatch) uncovered errors in type annotations of arguments of some generic `set` methods.