### PR TITLE
Fix null

### DIFF
--- a/lib/PHPExif/Adapter/AdapterAbstract.php
+++ b/lib/PHPExif/Adapter/AdapterAbstract.php
@@ -130,7 +130,7 @@ abstract class AdapterAbstract implements AdapterInterface
     public function convertToUTF8(array|string $data) : array|string
     {
         if (is_array($data)) {
-            /** @var array|string $v */
+            /** @var array|string|null $v */
             foreach ($data as $k => $v) {
                 if ($v !== null) {
                     $data[$k] = $this->convertToUTF8($v);

--- a/lib/PHPExif/Adapter/AdapterAbstract.php
+++ b/lib/PHPExif/Adapter/AdapterAbstract.php
@@ -132,7 +132,9 @@ abstract class AdapterAbstract implements AdapterInterface
         if (is_array($data)) {
             /** @var array|string $v */
             foreach ($data as $k => $v) {
-                $data[$k] = $this->convertToUTF8($v);
+                if ($v !== null) {
+                    $data[$k] = $this->convertToUTF8($v);
+                }
             }
         } else {
             $data = Encoding::toUTF8($data);


### PR DESCRIPTION
Another tweak necessitated by the additional annotations: Exif values can be `null` with the native adapter. I decided it was easiest to just handle that explicitly in the code, but feel free to come up with a better fix...