### PR TITLE
Ignore empty GPS data

### DIFF
--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -286,12 +286,13 @@ class Exiftool implements MapperInterface
                     }
                     break;
                 case self::GPSLATITUDE:
-                    $latitudeRef = !array_key_exists('GPS:GPSLatitudeRef', $data) ?
-                        'N' : $data['GPS:GPSLatitudeRef'][0];
                     $value = $this->extractGPSCoordinates($value);
                     if ($value === false) {
                         continue 2;
                     }
+                    $latitudeRef = !array_key_exists('GPS:GPSLatitudeRef', $data)
+                        || strlen($data['GPS:GPSLatitudeRef']) < 1 ?
+                        'N' : $data['GPS:GPSLatitudeRef'][0];
                     $value *= strtoupper($latitudeRef) === 'S' ? -1 : 1;
                     break;
                 case self::GPSLONGITUDE_QUICKTIME:
@@ -301,12 +302,13 @@ class Exiftool implements MapperInterface
                     }
                     break;
                 case self::GPSLONGITUDE:
-                    $longitudeRef = !array_key_exists('GPS:GPSLongitudeRef', $data) ?
-                        'E' : $data['GPS:GPSLongitudeRef'][0];
                     $value = $this->extractGPSCoordinates($value);
                     if ($value === false) {
                         continue 2;
                     }
+                    $longitudeRef = !array_key_exists('GPS:GPSLongitudeRef', $data)
+                        || strlen($data['GPS:GPSLongitudeRef']) < 1 ?
+                        'E' : $data['GPS:GPSLongitudeRef'][0];
                     $value *= strtoupper($longitudeRef) === 'W' ? -1 : 1;
                     break;
                 case self::GPSALTITUDE:

--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -291,7 +291,7 @@ class Exiftool implements MapperInterface
                         continue 2;
                     }
                     $latitudeRef = !array_key_exists('GPS:GPSLatitudeRef', $data)
-                        || strlen($data['GPS:GPSLatitudeRef']) < 1 ?
+                        || $data['GPS:GPSLatitudeRef'] === '' ?
                         'N' : $data['GPS:GPSLatitudeRef'][0];
                     $value *= strtoupper($latitudeRef) === 'S' ? -1 : 1;
                     break;
@@ -307,7 +307,7 @@ class Exiftool implements MapperInterface
                         continue 2;
                     }
                     $longitudeRef = !array_key_exists('GPS:GPSLongitudeRef', $data)
-                        || strlen($data['GPS:GPSLongitudeRef']) < 1 ?
+                        || $data['GPS:GPSLongitudeRef'] === '' ?
                         'E' : $data['GPS:GPSLongitudeRef'][0];
                     $value *= strtoupper($longitudeRef) === 'W' ? -1 : 1;
                     break;

--- a/lib/PHPExif/Mapper/Exiftool.php
+++ b/lib/PHPExif/Mapper/Exiftool.php
@@ -291,7 +291,7 @@ class Exiftool implements MapperInterface
                         continue 2;
                     }
                     $latitudeRef = !array_key_exists('GPS:GPSLatitudeRef', $data)
-                        || $data['GPS:GPSLatitudeRef'] === '' ?
+                        || $data['GPS:GPSLatitudeRef'] === null || $data['GPS:GPSLatitudeRef'] === '' ?
                         'N' : $data['GPS:GPSLatitudeRef'][0];
                     $value *= strtoupper($latitudeRef) === 'S' ? -1 : 1;
                     break;
@@ -307,7 +307,7 @@ class Exiftool implements MapperInterface
                         continue 2;
                     }
                     $longitudeRef = !array_key_exists('GPS:GPSLongitudeRef', $data)
-                        || $data['GPS:GPSLongitudeRef'] === '' ?
+                        || $data['GPS:GPSLongitudeRef'] === null || $data['GPS:GPSLongitudeRef'] === '' ?
                         'E' : $data['GPS:GPSLongitudeRef'][0];
                     $value *= strtoupper($longitudeRef) === 'W' ? -1 : 1;
                     break;

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -189,7 +189,7 @@ class ImageMagick implements MapperInterface
                         continue 2;
                     }
                     $latitudeRef = !array_key_exists('exif:GPSLatitudeRef', $data)
-                        || $data['exif:GPSLatitudeRef'] === '' ?
+                        || $data['exif:GPSLatitudeRef'] === null || $data['exif:GPSLatitudeRef'] === '' ?
                         'N' : $data['exif:GPSLatitudeRef'][0];
                     $value *= strtoupper($latitudeRef) === 'S' ? -1 : 1;
                     break;
@@ -199,7 +199,7 @@ class ImageMagick implements MapperInterface
                         continue 2;
                     }
                     $longitudeRef = !array_key_exists('exif:GPSLongitudeRef', $data)
-                        || $data['exif:GPSLongitudeRef'] === '' ?
+                        || $data['exif:GPSLongitudeRef'] === null || $data['exif:GPSLongitudeRef'] === '' ?
                         'E' : $data['exif:GPSLongitudeRef'][0];
                     $value *= strtoupper($longitudeRef) === 'W' ? -1 : 1;
                     break;

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -189,7 +189,7 @@ class ImageMagick implements MapperInterface
                         continue 2;
                     }
                     $latitudeRef = !array_key_exists('exif:GPSLatitudeRef', $data)
-                        || strlen($data['exif:GPSLatitudeRef']) < 1 ?
+                        || $data['exif:GPSLatitudeRef'] === '' ?
                         'N' : $data['exif:GPSLatitudeRef'][0];
                     $value *= strtoupper($latitudeRef) === 'S' ? -1 : 1;
                     break;
@@ -199,7 +199,7 @@ class ImageMagick implements MapperInterface
                         continue 2;
                     }
                     $longitudeRef = !array_key_exists('exif:GPSLongitudeRef', $data)
-                        || strlen($data['exif:GPSLongitudeRef']) < 1 ?
+                        || $data['exif:GPSLongitudeRef'] === '' ?
                         'E' : $data['exif:GPSLongitudeRef'][0];
                     $value *= strtoupper($longitudeRef) === 'W' ? -1 : 1;
                     break;

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -184,21 +184,23 @@ class ImageMagick implements MapperInterface
                     $value = preg_split('/([\s,]+)/', $value)[0];
                     break;
                 case self::GPSLATITUDE:
-                    $latitudeRef = !array_key_exists('exif:GPSLatitudeRef', $data) ?
-                        'N' : $data['exif:GPSLatitudeRef'][0];
                     $value = $this->extractGPSCoordinates($value);
                     if ($value === false) {
                         continue 2;
                     }
+                    $latitudeRef = !array_key_exists('exif:GPSLatitudeRef', $data)
+                        || strlen($data['exif:GPSLatitudeRef']) < 1 ?
+                        'N' : $data['exif:GPSLatitudeRef'][0];
                     $value *= strtoupper($latitudeRef) === 'S' ? -1 : 1;
                     break;
                 case self::GPSLONGITUDE:
-                    $longitudeRef = !array_key_exists('exif:GPSLongitudeRef', $data) ?
-                        'E' : $data['exif:GPSLongitudeRef'][0];
                     $value  = $this->extractGPSCoordinates($value);
                     if ($value === false) {
                         continue 2;
                     }
+                    $longitudeRef = !array_key_exists('exif:GPSLongitudeRef', $data)
+                        || strlen($data['exif:GPSLongitudeRef']) < 1 ?
+                        'E' : $data['exif:GPSLongitudeRef'][0];
                     $value *= strtoupper($longitudeRef) === 'W' ? -1 : 1;
                     break;
                 case self::GPSALTITUDE:

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -236,7 +236,8 @@ class Native implements MapperInterface
                     break;
                 case self::GPSLATITUDE:
                     $GPSLatitudeRef = '';
-                    if (array_key_exists('GPSLatitudeRef', $data) && $data['GPSLatitudeRef'][0] !== '') {
+                    if (array_key_exists('GPSLatitudeRef', $data)
+                        && $data['GPSLatitudeRef'] !== null && $data['GPSLatitudeRef'][0] !== '') {
                         $GPSLatitudeRef = $data['GPSLatitudeRef'][0];
                     }
                     $value = $this->extractGPSCoordinate((array)$value, $GPSLatitudeRef);
@@ -246,7 +247,8 @@ class Native implements MapperInterface
                     break;
                 case self::GPSLONGITUDE:
                     $GPSLongitudeRef = '';
-                    if (array_key_exists('GPSLongitudeRef', $data) && $data['GPSLongitudeRef'][0] !== '') {
+                    if (array_key_exists('GPSLongitudeRef', $data)
+                        && $data['GPSLongitudeRef'] !== null && $data['GPSLongitudeRef'][0] !== '') {
                         $GPSLongitudeRef = $data['GPSLongitudeRef'][0];
                     }
                     $value = $this->extractGPSCoordinate((array)$value, $GPSLongitudeRef);
@@ -255,16 +257,16 @@ class Native implements MapperInterface
                     }
                     break;
                 case self::GPSALTITUDE:
+                    $value = $this->normalizeComponent($value);
+                    if ($value === false) {
+                        continue 2;
+                    }
                     $flp = 1;
                     if (array_key_exists('GPSAltitudeRef', $data) && $data['GPSAltitudeRef'][0] !== '') {
                         $flp = (
                             $data['GPSAltitudeRef'][0] === '1'
                             || $data['GPSAltitudeRef'][0] === "\u{0001}"
                         ) ? -1 : 1;
-                    }
-                    $value = $this->normalizeComponent($value);
-                    if ($value === false) {
-                        continue 2;
                     }
                     $value *= $flp;
                     break;

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -235,7 +235,7 @@ class Native implements MapperInterface
                     $value = (int) reset($resolutionParts);
                     break;
                 case self::GPSLATITUDE:
-                    $GPSLatitudeRef = '';
+                    $GPSLatitudeRef = 'N';
                     if (array_key_exists('GPSLatitudeRef', $data)
                         && $data['GPSLatitudeRef'] !== null && $data['GPSLatitudeRef'][0] !== '') {
                         $GPSLatitudeRef = $data['GPSLatitudeRef'][0];
@@ -246,7 +246,7 @@ class Native implements MapperInterface
                     }
                     break;
                 case self::GPSLONGITUDE:
-                    $GPSLongitudeRef = '';
+                    $GPSLongitudeRef = 'E';
                     if (array_key_exists('GPSLongitudeRef', $data)
                         && $data['GPSLongitudeRef'] !== null && $data['GPSLongitudeRef'][0] !== '') {
                         $GPSLongitudeRef = $data['GPSLongitudeRef'][0];

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -404,6 +404,24 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\Exiftool::mapRawData
      */
+    public function testMapRawDataCorrectlyIgnoresEmptyGPSData()
+    {
+        $result = $this->mapper->mapRawData(
+            array(
+                \PHPExif\Mapper\Exiftool::GPSLATITUDE  => '',
+                'GPS:GPSLatitudeRef'                   => '',
+                \PHPExif\Mapper\Exiftool::GPSLONGITUDE => '',
+                'GPS:GPSLongitudeRef'                  => '',
+            )
+        );
+
+	$this->assertEquals(false, reset($result));
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     */
     public function testMapRawDataCorrectlyIgnoresIncorrectImageDirection()
     {
         $rawData = array(
@@ -510,6 +528,21 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
         );
         $expected = '-122.053';
         $this->assertEquals($expected, reset($result));
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     */
+    public function testMapRawDataCorrectlyIgnoresIncorrectAltitude()
+    {
+        $result = $this->mapper->mapRawData(
+            array(
+                \PHPExif\Mapper\Exiftool::GPSALTITUDE  => 'undef',
+                'GPS:GPSAltitudeRef'                   => '0',
+            )
+        );
+        $this->assertEquals(false, reset($result));
     }
 
     /**

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -415,7 +415,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-	$this->assertEquals(false, reset($result));
+        $this->assertEquals(false, reset($result));
     }
 
     /**

--- a/tests/PHPExif/Mapper/ImageMagickMapperTest.php
+++ b/tests/PHPExif/Mapper/ImageMagickMapperTest.php
@@ -361,9 +361,9 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
         $result = $this->mapper->mapRawData(
             array(
                 \PHPExif\Mapper\ImageMagick::GPSLATITUDE  => '40/1 20/1 42857/100000',
-                'GPS:GPSLatitudeRef'                   => 'N',
+                'exif:GPSLatitudeRef'                     => 'N',
                 \PHPExif\Mapper\ImageMagick::GPSLONGITUDE => '20/1 10/1 233333/100000',
-                'GPS:GPSLongitudeRef'                  => 'W',
+                'exif:GPSLongitudeRef'                    => 'W',
             )
         );
         $this->assertCount(0, $result);
@@ -402,11 +402,29 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
         $result = $this->mapper->mapRawData(
             array(
                 \PHPExif\Mapper\ImageMagick::GPSLATITUDE => '40.333452381',
-                'GPS:GPSLatitudeRef'                  => 'North',
+                'exif:GPSLatitudeRef'                    => 'North',
             )
         );
 
         $this->assertCount(1, $result);
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     */
+    public function testMapRawDataCorrectlyIgnoresEmptyGPSData()
+    {
+        $result = $this->mapper->mapRawData(
+            array(
+                \PHPExif\Mapper\ImageMagick::GPSLATITUDE  => '0/0, 0/0, 0/0',
+                'exif:GPSLatitudeRef'                     => '',
+                \PHPExif\Mapper\ImageMagick::GPSLONGITUDE => '0/0, 0/0, 0/0',
+                'exif:GPSLongitudeRef'                    => '',
+            )
+        );
+
+        $this->assertEquals(false, reset($result));
     }
 
 
@@ -475,6 +493,21 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
         );
         $expected = '-122.053';
         $this->assertEquals($expected, reset($result));
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     */
+    public function testMapRawDataCorrectlyIgnoresIncorrectAltitude()
+    {
+        $result = $this->mapper->mapRawData(
+            array(
+                \PHPExif\Mapper\ImageMagick::GPSALTITUDE  => '0/0',
+                'exif:GPSAltitudeRef'                     => '0',
+            )
+        );
+        $this->assertEquals(false, reset($result));
     }
 
 

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -349,6 +349,24 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
      * @group mapper
      * @covers \PHPExif\Mapper\Native::mapRawData
      */
+    public function testMapRawDataCorrectlyIgnoresEmptyGPSData()
+    {
+        $result = $this->mapper->mapRawData(
+            array(
+                'GPSLatitude'     => array('0/0', '0/0', '0/0'),
+                'GPSLatitudeRef'  => null,
+                'GPSLongitude'    => array('0/0', '0/0', '0/0'),
+                'GPSLongitudeRef' => null,
+            )
+        );
+
+        $this->assertEquals(false, reset($result));
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
     public function testMapRawDataCorrectlyFormatsAltitudeData()
     {
         $expected = array(
@@ -366,6 +384,21 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
             $result = $this->mapper->mapRawData($value);
             $this->assertEquals($key, $result[\PHPExif\Exif::ALTITUDE]);
         }
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
+    public function testMapRawDataCorrectlyIgnoresIncorrectAltitude()
+    {
+        $result = $this->mapper->mapRawData(
+            array(
+                'GPSAltitude'     => "0/0",
+                'GPSAltitudeRef'  => chr(0),
+            )
+        );
+        $this->assertEquals(false, reset($result));
     }
 
     public function testMapRawDataCorrectlyFormatsDifferentDateTimeString()


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee/issues/1406

The image in question has empty (rather than missing) GPS data, which none of our metadata mappers was prepared for.