### PR TITLE
Fix empty values

### DIFF
--- a/lib/PHPExif/Hydrator/Mutator.php
+++ b/lib/PHPExif/Hydrator/Mutator.php
@@ -33,10 +33,12 @@ class Mutator implements HydratorInterface
     public function hydrate($object, array $data) : void
     {
         foreach ($data as $property => $value) {
-            $mutator = $this->determineMutator($property);
+            if ($value !== null && $value !== '') {
+                $mutator = $this->determineMutator($property);
 
-            if (method_exists($object, $mutator)) {
-                $object->$mutator($value); // @phpstan-ignore-line, PhpStan does not like variadic calls
+                if (method_exists($object, $mutator)) {
+                    $object->$mutator($value); // @phpstan-ignore-line, PhpStan does not like variadic calls
+                }
             }
         }
     }

--- a/tests/PHPExif/Hydrator/MutatorTest.php
+++ b/tests/PHPExif/Hydrator/MutatorTest.php
@@ -79,8 +79,8 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
             ->setMethods(array('setFoo', 'setBar'))
             ->getMock();
 
-	$mock->expects($this->exactly(1))
-	    ->method('setFoo');
+        $mock->expects($this->exactly(1))
+            ->method('setFoo');
         $mock->expects($this->exactly(1))
             ->method('setBar');
 

--- a/tests/PHPExif/Hydrator/MutatorTest.php
+++ b/tests/PHPExif/Hydrator/MutatorTest.php
@@ -79,9 +79,9 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
             ->setMethods(array('setFoo', 'setBar'))
             ->getMock();
 
-        $mock->expects($this->exactly(1))
+        $mock->expects($this->exactly(0))
             ->method('setFoo');
-        $mock->expects($this->exactly(1))
+        $mock->expects($this->exactly(0))
             ->method('setBar');
 
         // do the test

--- a/tests/PHPExif/Hydrator/MutatorTest.php
+++ b/tests/PHPExif/Hydrator/MutatorTest.php
@@ -61,10 +61,41 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
         $hydrator = new \PHPExif\Hydrator\Mutator;
         $hydrator->hydrate($mock, $input);
     }
+
+    /**
+     * @group hydrator
+     * @covers \PHPExif\Hydrator\Mutator::hydrate
+     */
+    public function testHydrateCallsEmptyValues()
+    {
+        // input data
+        $input = array(
+            'foo' => null,
+            'bar' => '',
+        );
+
+        // create mock
+        $mock = $this->getMockBuilder('TestClass')
+            ->setMethods(array('setFoo', 'setBar'))
+            ->getMock();
+
+	$mock->expects($this->exactly(1))
+	    ->method('setFoo');
+        $mock->expects($this->exactly(1))
+            ->method('setBar');
+
+        // do the test
+        $hydrator = new \PHPExif\Hydrator\Mutator;
+        $hydrator->hydrate($mock, $input);
+    }
 }
 
 class TestClass
 {
+    public function setFoo()
+    {
+    }
+
     public function setBar()
     {
     }


### PR DESCRIPTION
Changes the generic hydrator to ignore tags with values that are `null` or empty. Especially the former are problematic as the relevant access methods typically operate on strings only.

This will fix https://github.com/LycheeOrg/Lychee/issues/1410.