### PR TITLE
Various fixes

### DIFF
--- a/lib/PHPExif/Adapter/Native.php
+++ b/lib/PHPExif/Adapter/Native.php
@@ -195,16 +195,17 @@ class Native extends AdapterAbstract
         $sections   = implode(',', $sections);
         $sections   = $sections === '' ? null : $sections;
 
-        try {
-            $data = exif_read_data(
-                $file,
-                $sections,
-                $this->getSectionsAsArrays(),
-                $this->getIncludeThumbnail()
-            );
-        } catch (\Throwable) {
-            $data = false;
-        }
+        // exif_read_data raises E_WARNING/E_NOTICE errors for unsupported
+	// tags, which could result in exceptions being thrown, even though
+	// the function would otherwise succeed to return valid tags.
+	// We explicitly disable this undesirable behavior.
+	// @phpstan-ignore-next-line
+        $data = @exif_read_data(
+            $file,
+            $sections,
+            $this->getSectionsAsArrays(),
+            $this->getIncludeThumbnail()
+        );
 
         // exif_read_data failed to read exif data (i.e. not a jpg/tiff)
         if (false === $data) {

--- a/lib/PHPExif/Adapter/Native.php
+++ b/lib/PHPExif/Adapter/Native.php
@@ -196,10 +196,10 @@ class Native extends AdapterAbstract
         $sections   = $sections === '' ? null : $sections;
 
         // exif_read_data raises E_WARNING/E_NOTICE errors for unsupported
-	// tags, which could result in exceptions being thrown, even though
-	// the function would otherwise succeed to return valid tags.
-	// We explicitly disable this undesirable behavior.
-	// @phpstan-ignore-next-line
+        // tags, which could result in exceptions being thrown, even though
+        // the function would otherwise succeed to return valid tags.
+        // We explicitly disable this undesirable behavior.
+        // @phpstan-ignore-next-line
         $data = @exif_read_data(
             $file,
             $sections,

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -57,6 +57,19 @@ class ImageMagick implements MapperInterface
     const SOFTWARE                 = 'exif:Software';
     const XRESOLUTION              = 'exif:XResolution';
     const YRESOLUTION              = 'exif:YResolution';
+    const TITLE                    = 'iptc:title';
+    const KEYWORDS                 = 'iptc:keywords';
+    const COPYRIGHT                = 'iptc:copyright';
+    const CAPTION                  = 'iptc:caption';
+    const HEADLINE                 = 'iptc:headline';
+    const CREDIT                   = 'iptc:credit';
+    const SOURCE                   = 'iptc:source';
+    const JOBTITLE                 = 'iptc:jobtitle';
+    const CITY                     = 'iptc:city';
+    const SUBLOCATION              = 'iptc:sublocation';
+    const STATE                    = 'iptc:state';
+    const COUNTRY                  = 'iptc:country';
+
 
     /**
      * Maps the ExifTool fields to the fields of
@@ -91,8 +104,20 @@ class ImageMagick implements MapperInterface
         self::MODEL                    => Exif::CAMERA,
         self::ORIENTATION              => Exif::ORIENTATION,
         self::SOFTWARE                 => Exif::SOFTWARE,
+        self::XRESOLUTION              => Exif::HORIZONTAL_RESOLUTION,
         self::YRESOLUTION              => Exif::VERTICAL_RESOLUTION,
-
+        self::TITLE                    => Exif::TITLE,
+        self::KEYWORDS                 => Exif::KEYWORDS,
+        self::COPYRIGHT                => Exif::COPYRIGHT,
+        self::CAPTION                  => Exif::CAPTION,
+        self::HEADLINE                 => Exif::HEADLINE,
+        self::CREDIT                   => Exif::CREDIT,
+        self::SOURCE                   => Exif::SOURCE,
+        self::JOBTITLE                 => EXIF::JOB_TITLE,
+        self::CITY                     => Exif::CITY,
+        self::SUBLOCATION              => Exif::SUBLOCATION,
+        self::STATE                    => Exif::STATE,
+        self::COUNTRY                  => Exif::COUNTRY
 
     );
 
@@ -183,6 +208,11 @@ class ImageMagick implements MapperInterface
                 case self::ISO:
                     $value = preg_split('/([\s,]+)/', $value)[0];
                     break;
+                case self::XRESOLUTION:
+                case self::YRESOLUTION:
+                    $resolutionParts = explode('/', $value);
+                    $value = (int) reset($resolutionParts);
+                    break;
                 case self::GPSLATITUDE:
                     $value = $this->extractGPSCoordinates($value);
                     if ($value === false) {
@@ -227,6 +257,11 @@ class ImageMagick implements MapperInterface
                         continue 2;
                     }
                     break;
+                case self::KEYWORDS:
+                    if (!is_array($value)) {
+                        $value = [$value];
+                    }
+                    break;
             }
             // set end result
             $mappedData[$key] = $value;
@@ -250,13 +285,13 @@ class ImageMagick implements MapperInterface
         if (is_numeric($coordinates) === true) {
             return ((float) $coordinates);
         } else {
-            $m = '!^([0-9]+\/[1-9][0-9]*), ([0-9]+\/[1-9][0-9]*), ([0-9]+\/[1-9][0-9]*)!';
+            $m = '!^([0-9]+\/[1-9][0-9]*)(?:, ([0-9]+\/[1-9][0-9]*))?(?:, ([0-9]+\/[1-9][0-9]*))?$!';
             if (preg_match($m, $coordinates, $matches) === 0) {
                 return false;
             }
             $degrees = $this->normalizeComponent($matches[1]);
-            $minutes = $this->normalizeComponent($matches[2]);
-            $seconds = $this->normalizeComponent($matches[3]);
+            $minutes = count($matches) > 2 ? $this->normalizeComponent($matches[2]) : 0;
+            $seconds = count($matches) > 3 ? $this->normalizeComponent($matches[3]) : 0;
             if ($degrees === false || $minutes === false || $seconds === false) {
                 return false;
             }

--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -290,8 +290,8 @@ class ImageMagick implements MapperInterface
                 return false;
             }
             $degrees = $this->normalizeComponent($matches[1]);
-            $minutes = count($matches) > 2 ? $this->normalizeComponent($matches[2]) : 0;
-            $seconds = count($matches) > 3 ? $this->normalizeComponent($matches[3]) : 0;
+            $minutes = $this->normalizeComponent($matches[2] ?? 0);
+            $seconds = $this->normalizeComponent($matches[3] ?? 0);
             if ($degrees === false || $minutes === false || $seconds === false) {
                 return false;
             }

--- a/lib/PHPExif/Mapper/Native.php
+++ b/lib/PHPExif/Mapper/Native.php
@@ -276,6 +276,18 @@ class Native implements MapperInterface
                         continue 2;
                     }
                     break;
+                // Merge sources of keywords
+                case self::KEYWORDS:
+                case self::SUBJECT:
+                    $xval = is_array($value) ? $value : [$value];
+                    if (!array_key_exists(Exif::KEYWORDS, $mappedData)) {
+                        $mappedData[Exif::KEYWORDS] = $xval;
+                    } else {
+                        $tmp = array_values(array_unique(array_merge($mappedData[Exif::KEYWORDS], $xval)));
+                        $mappedData[Exif::KEYWORDS] = $tmp;
+                    }
+
+                    continue 2;
                 case self::LENS_LR:
                     if (!array_key_exists(Exif::LENS, $mappedData)) {
                         $mappedData[Exif::LENS] = $value;

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -871,10 +871,12 @@ class ExifTest extends \PHPUnit\Framework\TestCase
         );
 
         $adapter_exiftool = new \PHPExif\Adapter\Exiftool();
+        $adapter_imagemagick = new \PHPExif\Adapter\ImageMagick();
         $adapter_native = new \PHPExif\Adapter\Native();
 
         foreach ($testfiles as $file) {
             $result_exiftool = $adapter_exiftool->getExifFromFile($file);
+            $result_imagemagick = $adapter_imagemagick->getExifFromFile($file);
             $result_native = $adapter_native->getExifFromFile($file);
 
             // find all Getter methods on the results and compare its output
@@ -886,6 +888,11 @@ class ExifTest extends \PHPUnit\Framework\TestCase
                 $this->assertEquals(
                     call_user_func(array($result_native, $name)),
                     call_user_func(array($result_exiftool, $name)),
+                    'Adapter difference detected in method "' . $name . '" on image "' . basename($file) . '"'
+                );
+                $this->assertEquals(
+                    call_user_func(array($result_native, $name)),
+                    call_user_func(array($result_imagemagick, $name)),
                     'Adapter difference detected in method "' . $name . '" on image "' . basename($file) . '"'
                 );
             }

--- a/tests/PHPExif/Mapper/ImageMagickMapperTest.php
+++ b/tests/PHPExif/Mapper/ImageMagickMapperTest.php
@@ -605,5 +605,69 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
           }
       }
 
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     */
+    public function testMapRawDataCorrectlyKeywords()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\ImageMagick::KEYWORDS => 'Keyword_1 Keyword_2',
+        );
 
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(
+            ['Keyword_1 Keyword_2'],
+            reset($mapped)
+        );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     */
+    public function testMapRawDataCorrectlyKeywordsAndSubject()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\ImageMagick::KEYWORDS => array('Keyword_1', 'Keyword_2'),
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(
+            array('Keyword_1' ,'Keyword_2'),
+            reset($mapped)
+        );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     */
+    public function testMapRawDataCorrectlyFormatsXResolution()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\ImageMagick::XRESOLUTION => '1500/300',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(1500, reset($mapped));
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     */
+    public function testMapRawDataCorrectlyFormatsYResolution()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\ImageMagick::YRESOLUTION => '1500/300',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(1500, reset($mapped));
+    }
 }

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -546,4 +546,41 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
             );
         }
     }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
+    public function testMapRawDataCorrectlyKeywords()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\Native::KEYWORDS => 'Keyword_1 Keyword_2',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(
+            ['Keyword_1 Keyword_2'],
+            reset($mapped)
+        );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\Native::mapRawData
+     */
+    public function testMapRawDataCorrectlyKeywordsAndSubject()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\Native::KEYWORDS => array('Keyword_1', 'Keyword_2'),
+            \PHPExif\Mapper\Native::SUBJECT => array('Keyword_1', 'Keyword_3'),
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(
+            array('Keyword_1' ,'Keyword_2', 'Keyword_3'),
+            reset($mapped)
+        );
+    }
 }


### PR DESCRIPTION
An assortment of fixes for recently seen problems.

* Reverts a change to `exif_read_data` from #43 -- we do actually need to suppress the warnings using `@` there. This is part of a fix for https://github.com/LycheeOrg/Lychee/issues/1432.
* Expands a fix from #39 to the native adapter and ImageMagick. This *might* be a fix for https://github.com/LycheeOrg/Lychee/issues/1431 based on the preview image that I was able to download, but without cooperation from the reporter I can't be sure.
* Expands the ImageMagick adapter to support IPTC data -- largely copied over from Native. This primarily adds support for importing keywords (tags).
* Expands testing of the ImageMagick adapter; this uncovered a couple more issues:
  * Support for XResolution/YResolution tags was incomplete.
  * GPS data parser could not handle partial (but correct) data (missing minutes or seconds).