### PR TITLE
function always return an Exif object + fix tests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -407,16 +407,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.2.5",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "cfe2d7c87d55b04cbde8fe3c137d9dd66e5d83f4"
+                "reference": "76babfd82f6bfd8f6cbe851a153b95dd074ffc53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/cfe2d7c87d55b04cbde8fe3c137d9dd66e5d83f4",
-                "reference": "cfe2d7c87d55b04cbde8fe3c137d9dd66e5d83f4",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/76babfd82f6bfd8f6cbe851a153b95dd074ffc53",
+                "reference": "76babfd82f6bfd8f6cbe851a153b95dd074ffc53",
                 "shasum": ""
             },
             "require": {
@@ -425,7 +425,7 @@
                 "psr/log": "^1.1|^2|^3",
                 "symfony/cache-contracts": "^1.1.7|^2|^3",
                 "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/var-exporter": "^6.2"
+                "symfony/var-exporter": "^6.2.7"
             },
             "conflict": {
                 "doctrine/dbal": "<2.13.1",
@@ -483,7 +483,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.2.5"
+                "source": "https://github.com/symfony/cache/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -499,20 +499,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:45:48+00:00"
+            "time": "2023-03-30T07:37:32+00:00"
         },
         {
             "name": "symfony/cache-contracts",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "e8d1a5fc43534063204b74c080ebe36307d12271"
+                "reference": "eeb71f04b6f7f34ca6d15633df82e014528b1632"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/e8d1a5fc43534063204b74c080ebe36307d12271",
-                "reference": "e8d1a5fc43534063204b74c080ebe36307d12271",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/eeb71f04b6f7f34ca6d15633df82e014528b1632",
+                "reference": "eeb71f04b6f7f34ca6d15633df82e014528b1632",
                 "shasum": ""
             },
             "require": {
@@ -562,7 +562,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.2.0"
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -578,20 +578,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T10:21:52+00:00"
+            "time": "2023-03-01T10:32:47+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.2.5",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "9ead139f63dfa38c4e4a9049cc64a8b2748c83b7"
+                "reference": "75ed64103df4f6615e15a7fe38b8111099f47416"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/9ead139f63dfa38c4e4a9049cc64a8b2748c83b7",
-                "reference": "9ead139f63dfa38c4e4a9049cc64a8b2748c83b7",
+                "url": "https://api.github.com/repos/symfony/process/zipball/75ed64103df4f6615e15a7fe38b8111099f47416",
+                "reference": "75ed64103df4f6615e15a7fe38b8111099f47416",
                 "shasum": ""
             },
             "require": {
@@ -623,7 +623,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.2.5"
+                "source": "https://github.com/symfony/process/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -639,20 +639,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:38:09+00:00"
+            "time": "2023-03-09T16:20:02+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75"
+                "reference": "a8c9cedf55f314f3a186041d19537303766df09a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/aac98028c69df04ee77eb69b96b86ee51fbf4b75",
-                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a8c9cedf55f314f3a186041d19537303766df09a",
+                "reference": "a8c9cedf55f314f3a186041d19537303766df09a",
                 "shasum": ""
             },
             "require": {
@@ -708,7 +708,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.2.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -724,20 +724,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T10:21:52+00:00"
+            "time": "2023-03-01T10:32:47+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.2.5",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "108f9c6451eea8e04a7fb83bbacb5b812ef30e35"
+                "reference": "8302bb670204500d492c6b8c595ee9a27da62cd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/108f9c6451eea8e04a7fb83bbacb5b812ef30e35",
-                "reference": "108f9c6451eea8e04a7fb83bbacb5b812ef30e35",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/8302bb670204500d492c6b8c595ee9a27da62cd6",
+                "reference": "8302bb670204500d492c6b8c595ee9a27da62cd6",
                 "shasum": ""
             },
             "require": {
@@ -777,12 +777,12 @@
                 "export",
                 "hydrate",
                 "instantiate",
-                "lazy loading",
+                "lazy-loading",
                 "proxy",
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.2.5"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -798,7 +798,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-13T08:35:57+00:00"
+            "time": "2023-03-14T15:48:45+00:00"
         },
         {
             "name": "thecodingmachine/safe",
@@ -1536,16 +1536,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.14.4",
+            "version": "v3.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "1b3d9dba63d93b8a202c31e824748218781eae6b"
+                "reference": "d40f9436e1c448d309fa995ab9c14c5c7a96f2dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/1b3d9dba63d93b8a202c31e824748218781eae6b",
-                "reference": "1b3d9dba63d93b8a202c31e824748218781eae6b",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d40f9436e1c448d309fa995ab9c14c5c7a96f2dc",
+                "reference": "d40f9436e1c448d309fa995ab9c14c5c7a96f2dc",
                 "shasum": ""
             },
             "require": {
@@ -1612,9 +1612,15 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.14.4"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.16.0"
             },
             "funding": [
                 {
@@ -1622,7 +1628,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-09T21:49:13+00:00"
+            "time": "2023-04-02T19:30:06+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -2050,16 +2056,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -2097,7 +2103,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -2105,7 +2111,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "nette/utils",
@@ -2195,16 +2201,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
                 "shasum": ""
             },
             "require": {
@@ -2245,9 +2251,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-03-05T19:49:14+00:00"
         },
         {
             "name": "ondram/ci-detector",
@@ -2329,16 +2335,16 @@
         },
         {
             "name": "pdepend/pdepend",
-            "version": "2.12.1",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "7a892d56ceafd804b4a2ecc85184640937ce9e84"
+                "reference": "31be7cd4f305f3f7b52af99c1cb13fc938d1cfad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/7a892d56ceafd804b4a2ecc85184640937ce9e84",
-                "reference": "7a892d56ceafd804b4a2ecc85184640937ce9e84",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/31be7cd4f305f3f7b52af99c1cb13fc938d1cfad",
+                "reference": "31be7cd4f305f3f7b52af99c1cb13fc938d1cfad",
                 "shasum": ""
             },
             "require": {
@@ -2374,7 +2380,7 @@
             "description": "Official version of pdepend to be handled with Composer",
             "support": {
                 "issues": "https://github.com/pdepend/pdepend/issues",
-                "source": "https://github.com/pdepend/pdepend/tree/2.12.1"
+                "source": "https://github.com/pdepend/pdepend/tree/2.13.0"
             },
             "funding": [
                 {
@@ -2382,7 +2388,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-08T19:30:37+00:00"
+            "time": "2023-02-28T20:56:15+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2637,16 +2643,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.16.1",
+            "version": "1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571"
+                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/e27e92d939e2e3636f0a1f0afaba59692c0bf571",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
+                "reference": "d3753fcb3abc6f78f5de6f72153d4b9c99c72dee",
                 "shasum": ""
             },
             "require": {
@@ -2676,22 +2682,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.16.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.17.1"
             },
-            "time": "2023-02-07T18:11:17+00:00"
+            "time": "2023-04-04T11:11:22+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.17",
+            "version": "1.10.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "204e459e7822f2c586463029f5ecec31bb45a1f2"
+                "reference": "8aa62e6ea8b58ffb650e02940e55a788cbc3fe21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/204e459e7822f2c586463029f5ecec31bb45a1f2",
-                "reference": "204e459e7822f2c586463029f5ecec31bb45a1f2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8aa62e6ea8b58ffb650e02940e55a788cbc3fe21",
+                "reference": "8aa62e6ea8b58ffb650e02940e55a788cbc3fe21",
                 "shasum": ""
             },
             "require": {
@@ -2720,8 +2726,11 @@
                 "static analysis"
             ],
             "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.17"
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
             "funding": [
                 {
@@ -2737,25 +2746,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-08T12:25:00+00:00"
+            "time": "2023-04-04T19:17:42+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
-            "version": "1.1.1",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
-                "reference": "2c6792eda026d9c474c14aa018aed312686714db"
+                "reference": "a22b36b955a2e9a3d39fe533b6c1bb5359f9c319"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/2c6792eda026d9c474c14aa018aed312686714db",
-                "reference": "2c6792eda026d9c474c14aa018aed312686714db",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/a22b36b955a2e9a3d39fe533b6c1bb5359f9c319",
+                "reference": "a22b36b955a2e9a3d39fe533b6c1bb5359f9c319",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.9.3"
+                "phpstan/phpstan": "^1.10"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -2783,31 +2792,32 @@
             "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.1.1"
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.1.3"
             },
-            "time": "2022-12-13T14:26:20+00:00"
+            "time": "2023-03-17T07:50:08+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "1.4.5",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "361f75b06066f3fdaba87c1f57bdb1ffc28d6f1d"
+                "reference": "b21c03d4f6f3a446e4311155f4be9d65048218e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/361f75b06066f3fdaba87c1f57bdb1ffc28d6f1d",
-                "reference": "361f75b06066f3fdaba87c1f57bdb1ffc28d6f1d",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/b21c03d4f6f3a446e4311155f4be9d65048218e6",
+                "reference": "b21c03d4f6f3a446e4311155f4be9d65048218e6",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.9.7"
+                "phpstan/phpstan": "^1.10"
             },
             "require-dev": {
                 "nikic/php-parser": "^4.13.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpunit/phpunit": "^9.5"
             },
@@ -2831,29 +2841,29 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.4.5"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.5.1"
             },
-            "time": "2023-01-11T14:16:29+00:00"
+            "time": "2023-03-29T14:47:40+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.24",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -2868,8 +2878,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -2902,7 +2912,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -2910,7 +2920,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-26T08:26:55+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3155,16 +3165,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.3",
+            "version": "9.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555"
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e7b1615e3e887d6c719121c6d4a44b0ab9645555",
-                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
                 "shasum": ""
             },
             "require": {
@@ -3197,8 +3207,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -3237,7 +3247,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.3"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
             },
             "funding": [
                 {
@@ -3253,7 +3264,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-04T13:37:15+00:00"
+            "time": "2023-03-27T11:43:46+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -4464,16 +4475,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -4509,27 +4520,28 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "f31b3c78a3650157188a240695e688d6a182aa91"
+                "reference": "249271da6f545d6579e0663374f8249a80be2893"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/f31b3c78a3650157188a240695e688d6a182aa91",
-                "reference": "f31b3c78a3650157188a240695e688d6a182aa91",
+                "url": "https://api.github.com/repos/symfony/config/zipball/249271da6f545d6579e0663374f8249a80be2893",
+                "reference": "249271da6f545d6579e0663374f8249a80be2893",
                 "shasum": ""
             },
             "require": {
@@ -4577,7 +4589,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.2.5"
+                "source": "https://github.com/symfony/config/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4593,20 +4605,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-09T04:38:22+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.2.5",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3e294254f2191762c1d137aed4b94e966965e985"
+                "reference": "3582d68a64a86ec25240aaa521ec8bc2342b369b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3e294254f2191762c1d137aed4b94e966965e985",
-                "reference": "3e294254f2191762c1d137aed4b94e966965e985",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3582d68a64a86ec25240aaa521ec8bc2342b369b",
+                "reference": "3582d68a64a86ec25240aaa521ec8bc2342b369b",
                 "shasum": ""
             },
             "require": {
@@ -4668,12 +4680,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.2.5"
+                "source": "https://github.com/symfony/console/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -4689,20 +4701,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:38:09+00:00"
+            "time": "2023-03-29T21:42:15+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.2.6",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "2a6dd148589b9db59717db8b75f8d9fbb2ae714f"
+                "reference": "b6195feacceb88fc58a02b69522b569e4c6188ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2a6dd148589b9db59717db8b75f8d9fbb2ae714f",
-                "reference": "2a6dd148589b9db59717db8b75f8d9fbb2ae714f",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b6195feacceb88fc58a02b69522b569e4c6188ac",
+                "reference": "b6195feacceb88fc58a02b69522b569e4c6188ac",
                 "shasum": ""
             },
             "require": {
@@ -4710,7 +4722,7 @@
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/service-contracts": "^1.1.6|^2.0|^3.0",
-                "symfony/var-exporter": "^6.2"
+                "symfony/var-exporter": "^6.2.7"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
@@ -4760,7 +4772,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.2.6"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -4776,20 +4788,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-30T15:46:28+00:00"
+            "time": "2023-03-30T13:35:57+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3"
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/1ee04c65529dea5d8744774d474e7cbd2f1206d3",
-                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
                 "shasum": ""
             },
             "require": {
@@ -4827,7 +4839,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -4843,20 +4855,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T10:21:52+00:00"
+            "time": "2023-03-01T10:25:55+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.2.5",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f02d108b5e9fd4a6245aa73a9d2df2ec060c3e68"
+                "reference": "04046f35fd7d72f9646e721fc2ecb8f9c67d3339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f02d108b5e9fd4a6245aa73a9d2df2ec060c3e68",
-                "reference": "f02d108b5e9fd4a6245aa73a9d2df2ec060c3e68",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/04046f35fd7d72f9646e721fc2ecb8f9c67d3339",
+                "reference": "04046f35fd7d72f9646e721fc2ecb8f9c67d3339",
                 "shasum": ""
             },
             "require": {
@@ -4910,7 +4922,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.2.5"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -4926,20 +4938,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:38:09+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "0782b0b52a737a05b4383d0df35a474303cabdae"
+                "reference": "0ad3b6f1e4e2da5690fefe075cd53a238646d8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0782b0b52a737a05b4383d0df35a474303cabdae",
-                "reference": "0782b0b52a737a05b4383d0df35a474303cabdae",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ad3b6f1e4e2da5690fefe075cd53a238646d8dd",
+                "reference": "0ad3b6f1e4e2da5690fefe075cd53a238646d8dd",
                 "shasum": ""
             },
             "require": {
@@ -4989,7 +5001,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.2.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -5005,20 +5017,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T10:21:52+00:00"
+            "time": "2023-03-01T10:32:47+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e59e8a4006afd7f5654786a83b4fcb8da98f4593"
+                "reference": "82b6c62b959f642d000456f08c6d219d749215b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e59e8a4006afd7f5654786a83b4fcb8da98f4593",
-                "reference": "e59e8a4006afd7f5654786a83b4fcb8da98f4593",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/82b6c62b959f642d000456f08c6d219d749215b3",
+                "reference": "82b6c62b959f642d000456f08c6d219d749215b3",
                 "shasum": ""
             },
             "require": {
@@ -5052,7 +5064,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.2.5"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -5068,20 +5080,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:45:48+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "c90dc446976a612e3312a97a6ec0069ab0c2099c"
+                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/c90dc446976a612e3312a97a6ec0069ab0c2099c",
-                "reference": "c90dc446976a612e3312a97a6ec0069ab0c2099c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/20808dc6631aecafbe67c186af5dcb370be3a0eb",
+                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb",
                 "shasum": ""
             },
             "require": {
@@ -5116,7 +5128,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.2.5"
+                "source": "https://github.com/symfony/finder/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -5132,20 +5144,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:45:48+00:00"
+            "time": "2023-02-16T09:57:23+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "e8324d44f5af99ec2ccec849934a242f64458f86"
+                "reference": "aa0e85b53bbb2b4951960efd61d295907eacd629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/e8324d44f5af99ec2ccec849934a242f64458f86",
-                "reference": "e8324d44f5af99ec2ccec849934a242f64458f86",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/aa0e85b53bbb2b4951960efd61d295907eacd629",
+                "reference": "aa0e85b53bbb2b4951960efd61d295907eacd629",
                 "shasum": ""
             },
             "require": {
@@ -5183,7 +5195,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.2.5"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -5199,7 +5211,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:38:09+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5695,16 +5707,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "00b6ac156aacffc53487c930e0ab14587a6607f6"
+                "reference": "f3adc98c1061875dd2edcd45e5b04e63d0e29f8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/00b6ac156aacffc53487c930e0ab14587a6607f6",
-                "reference": "00b6ac156aacffc53487c930e0ab14587a6607f6",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f3adc98c1061875dd2edcd45e5b04e63d0e29f8f",
+                "reference": "f3adc98c1061875dd2edcd45e5b04e63d0e29f8f",
                 "shasum": ""
             },
             "require": {
@@ -5737,7 +5749,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v6.2.5"
+                "source": "https://github.com/symfony/stopwatch/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -5753,20 +5765,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:55+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.2.5",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0"
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
-                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
+                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
                 "shasum": ""
             },
             "require": {
@@ -5823,7 +5835,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.2.5"
+                "source": "https://github.com/symfony/string/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -5839,7 +5851,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:38:09+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "symplify/phpstan-rules",
@@ -5847,12 +5859,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/phpstan-rules.git",
-                "reference": "c050f01d219cf3b81b751731dbe1347a2c5e6354"
+                "reference": "1230c289d5d3d08c027988820e651507141e3605"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/phpstan-rules/zipball/c050f01d219cf3b81b751731dbe1347a2c5e6354",
-                "reference": "c050f01d219cf3b81b751731dbe1347a2c5e6354",
+                "url": "https://api.github.com/repos/symplify/phpstan-rules/zipball/1230c289d5d3d08c027988820e651507141e3605",
+                "reference": "1230c289d5d3d08c027988820e651507141e3605",
                 "shasum": ""
             },
             "require": {
@@ -5900,7 +5912,7 @@
             "description": "Set of Symplify rules for PHPStan",
             "support": {
                 "issues": "https://github.com/symplify/phpstan-rules/issues",
-                "source": "https://github.com/symplify/phpstan-rules/tree/11.2.4"
+                "source": "https://github.com/symplify/phpstan-rules/tree/main"
             },
             "funding": [
                 {
@@ -5912,7 +5924,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-14T19:49:25+00:00"
+            "time": "2023-03-31T09:38:29+00:00"
         },
         {
             "name": "symplify/rule-doc-generator-contracts",

--- a/lib/PHPExif/Adapter/FFprobe.php
+++ b/lib/PHPExif/Adapter/FFprobe.php
@@ -15,6 +15,7 @@ use PHPExif\Exif;
 use InvalidArgumentException;
 use FFMpeg;
 use PHPExif\Mapper\FFprobe as MapperFFprobe;
+use RuntimeException;
 use Safe\Exceptions\ExecException;
 
 use function Safe\exec;
@@ -91,9 +92,9 @@ class FFprobe extends AbstractAdapter
      * Reads & parses the EXIF data from given file
      *
      * @param string $file
-     * @return \PHPExif\Exif|false Instance of Exif object with data
+     * @return \PHPExif\Exif Instance of Exif object with data
      */
-    public function getExifFromFile(string $file): Exif|false
+    public function getExifFromFile(string $file): Exif
     {
         $mimeType = mime_content_type($file);
 
@@ -112,7 +113,7 @@ class FFprobe extends AbstractAdapter
 
         // file is not a video -> wrong adapter
         if (strpos($mimeType, 'video') !== 0) {
-            return false;
+            throw new RuntimeException('Could not read the video');
         }
 
         $ffprobe = FFMpeg\FFProbe::create(array(

--- a/lib/PHPExif/Contracts/AdapterInterface.php
+++ b/lib/PHPExif/Contracts/AdapterInterface.php
@@ -24,5 +24,5 @@ interface AdapterInterface
      * @return \PHPExif\Exif Instance of Exif object with data
      * @throws \RuntimeException If the EXIF data could not be read
      */
-    public function getExifFromFile(string $file) : Exif|false;
+    public function getExifFromFile(string $file) : Exif;
 }

--- a/lib/PHPExif/Contracts/HydratorInterface.php
+++ b/lib/PHPExif/Contracts/HydratorInterface.php
@@ -22,5 +22,5 @@ interface HydratorInterface
      * @param array $data
      * @return void
      */
-    public function hydrate($object, array $data);
+    public function hydrate($object, array $data): void;
 }

--- a/lib/PHPExif/Contracts/ReaderInterface.php
+++ b/lib/PHPExif/Contracts/ReaderInterface.php
@@ -23,5 +23,5 @@ interface ReaderInterface
      * @param string $file
      * @return \PHPExif\Exif Instance of Exif object with data
      */
-    public function read(string $file) : Exif|false|string;
+    public function read(string $file) : Exif;
 }

--- a/lib/PHPExif/Reader/Reader.php
+++ b/lib/PHPExif/Reader/Reader.php
@@ -68,7 +68,6 @@ class Reader implements ReaderInterface
             ReaderType::EXIFTOOL => new ExiftoolAdapter(),
             ReaderType::FFPROBE => new FFProbeAdapter(),
             ReaderType::IMAGICK => new ImageMagickAdapter(),
-            default => throw new \InvalidArgumentException(sprintf('Unknown type "%1$s"', $type->value))
         };
         return new $classname($adapter);
     }
@@ -79,7 +78,7 @@ class Reader implements ReaderInterface
      * @param string $file
      * @return \PHPExif\Exif Instance of Exif object with data
      */
-    public function read(string $file): Exif|string|false
+    public function read(string $file): Exif
     {
         return $this->getAdapter()->getExifFromFile($file);
     }
@@ -90,7 +89,7 @@ class Reader implements ReaderInterface
      * @param string $file
      * @return \PHPExif\Exif Instance of Exif object with data
      */
-    public function getExifFromFile(string $file): Exif|string|false
+    public function getExifFromFile(string $file): Exif
     {
         return $this->read($file);
     }

--- a/tests/PHPExif/Adapter/AdapterAbstractTest.php
+++ b/tests/PHPExif/Adapter/AdapterAbstractTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPExif\Adapter\AbstractAdapter;
 use PHPExif\Adapter\Exiftool;
 use PHPExif\Adapter\Native;
 
@@ -9,13 +10,13 @@ use PHPExif\Adapter\Native;
 class AbstractAdapterTest extends PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPExif\Adapter\Exiftool|\PHPExif\Adapter\Native
+     * @var Exiftool|Native
      */
     protected Exiftool|Native $adapter;
 
     protected function setUp(): void
     {
-        $this->adapter = new \PHPExif\Adapter\Native();
+        $this->adapter = new Native();
     }
 
     /**
@@ -36,13 +37,13 @@ class AbstractAdapterTest extends PHPUnit\Framework\TestCase
     {
         $expected = array(
             'requiredSections'  => array('foo', 'bar', 'baz',),
-            'includeThumbnail' => \PHPExif\Adapter\Native::INCLUDE_THUMBNAIL,
-            'sectionsAsArrays' => \PHPExif\Adapter\Native::SECTIONS_AS_ARRAYS,
+            'includeThumbnail' => Native::INCLUDE_THUMBNAIL,
+            'sectionsAsArrays' => Native::SECTIONS_AS_ARRAYS,
         );
         $this->adapter->setOptions($expected);
 
         foreach ($expected as $key => $value) {
-            $reflProp = new \ReflectionProperty('\\PHPExif\\Adapter\\Native', $key);
+            $reflProp = new \ReflectionProperty(Native::class, $key);
             $reflProp->setAccessible(true);
             $this->assertEquals($value, $reflProp->getValue($this->adapter));
         }
@@ -60,7 +61,7 @@ class AbstractAdapterTest extends PHPUnit\Framework\TestCase
         $this->adapter->setOptions($expected);
 
         foreach ($expected as $key => $value) {
-            $reflProp = new \ReflectionProperty('\\PHPExif\\Adapter\\Native', $key);
+            $reflProp = new \ReflectionProperty(Native::class, $key);
             $reflProp->setAccessible(true);
             $this->assertNotEquals($value, $reflProp->getValue($this->adapter));
         }
@@ -75,13 +76,13 @@ class AbstractAdapterTest extends PHPUnit\Framework\TestCase
     {
         $expected = array(
             'requiredSections'  => array('foo', 'bar', 'baz',),
-            'includeThumbnail' => \PHPExif\Adapter\Native::INCLUDE_THUMBNAIL,
-            'sectionsAsArrays' => \PHPExif\Adapter\Native::SECTIONS_AS_ARRAYS,
+            'includeThumbnail' => Native::INCLUDE_THUMBNAIL,
+            'sectionsAsArrays' => Native::SECTIONS_AS_ARRAYS,
         );
-        $adapter = new \PHPExif\Adapter\Native($expected);
+        $adapter = new Native($expected);
 
         foreach ($expected as $key => $value) {
-            $reflProp = new \ReflectionProperty('\\PHPExif\\Adapter\\Native', $key);
+            $reflProp = new \ReflectionProperty(Native::class, $key);
             $reflProp->setAccessible(true);
             $this->assertEquals($value, $reflProp->getValue($adapter));
         }
@@ -107,7 +108,7 @@ class AbstractAdapterTest extends PHPUnit\Framework\TestCase
         $mapper = new \PHPExif\Mapper\Native();
         $this->adapter->setMapper($mapper);
 
-        $reflProp = new \ReflectionProperty('\\PHPExif\\Adapter\\AbstractAdapter', 'mapper');
+        $reflProp = new \ReflectionProperty(AbstractAdapter::class, 'mapper');
         $reflProp->setAccessible(true);
         $this->assertSame($mapper, $reflProp->getValue($this->adapter));
     }
@@ -119,7 +120,7 @@ class AbstractAdapterTest extends PHPUnit\Framework\TestCase
     public function testGetMapperCorrectlyReturnsFromProperty()
     {
         $mapper = new \PHPExif\Mapper\Native();
-        $reflProp = new \ReflectionProperty('\\PHPExif\\Adapter\\AbstractAdapter', 'mapper');
+        $reflProp = new \ReflectionProperty(AbstractAdapter::class, 'mapper');
         $reflProp->setAccessible(true);
         $reflProp->setValue($this->adapter, $mapper);
         $this->assertSame($mapper, $this->adapter->getMapper());
@@ -187,7 +188,7 @@ class AbstractAdapterTest extends PHPUnit\Framework\TestCase
         $hydrator = new \PHPExif\Hydrator\Mutator();
         $this->adapter->setHydrator($hydrator);
 
-        $reflProp = new \ReflectionProperty('\\PHPExif\\Adapter\\AbstractAdapter', 'hydrator');
+        $reflProp = new \ReflectionProperty(AbstractAdapter::class, 'hydrator');
         $reflProp->setAccessible(true);
         $this->assertSame($hydrator, $reflProp->getValue($this->adapter));
     }
@@ -199,7 +200,7 @@ class AbstractAdapterTest extends PHPUnit\Framework\TestCase
     public function testGetHydratorCorrectlyReturnsFromProperty()
     {
         $hydrator = new \PHPExif\Hydrator\Mutator();
-        $reflProp = new \ReflectionProperty('\\PHPExif\\Adapter\\AbstractAdapter', 'hydrator');
+        $reflProp = new \ReflectionProperty(AbstractAdapter::class, 'hydrator');
         $reflProp->setAccessible(true);
         $reflProp->setValue($this->adapter, $hydrator);
         $this->assertSame($hydrator, $this->adapter->getHydrator());

--- a/tests/PHPExif/Adapter/ExiftoolProcOpenTest.php
+++ b/tests/PHPExif/Adapter/ExiftoolProcOpenTest.php
@@ -24,12 +24,12 @@ namespace PHPExif\Adapter
     }
 
     /**
-     * @covers \PHPExif\Adapter\Exiftool::<!public>
+     * @covers Exiftool::<!public>
      */
     class ExiftoolProcOpenTest extends \PHPUnit\Framework\TestCase
     {
         /**
-         * @var \PHPExif\Adapter\Exiftool
+         * @var Exiftool
          */
         protected $adapter;
 
@@ -37,7 +37,7 @@ namespace PHPExif\Adapter
         {
             global $mockProcOpen;
             $mockProcOpen = true;
-            $this->adapter = new \PHPExif\Adapter\Exiftool();
+            $this->adapter = new Exiftool();
         }
 
         public function tearDown() : void
@@ -48,12 +48,12 @@ namespace PHPExif\Adapter
 
         /**
          * @group exiftool
-         * @covers \PHPExif\Adapter\Exiftool::getCliOutput
+         * @covers Exiftool::getCliOutput
          */
         public function testGetCliOutput()
         {
             $this->expectException('RuntimeException');
-            $reflMethod = new \ReflectionMethod('\PHPExif\Adapter\Exiftool', 'getCliOutput');
+            $reflMethod = new \ReflectionMethod(Exiftool::class, 'getCliOutput');
             $reflMethod->setAccessible(true);
 
             $result = $reflMethod->invoke(

--- a/tests/PHPExif/Adapter/ExiftoolTest.php
+++ b/tests/PHPExif/Adapter/ExiftoolTest.php
@@ -3,7 +3,7 @@
 use PHPExif\Adapter\Exiftool;
 
 /**
- * @covers \PHPExif\Adapter\Exiftool::<!public>
+ * @covers Exiftool::<!public>
  */
 class ExiftoolTest extends \PHPUnit\Framework\TestCase
 {
@@ -11,16 +11,16 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        $this->adapter = new \PHPExif\Adapter\Exiftool();
+        $this->adapter = new Exiftool();
     }
 
     /**
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::getToolPath
+     * @covers Exiftool::getToolPath
      */
     public function testGetToolPathFromProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Exiftool', 'toolPath');
+        $reflProperty = new \ReflectionProperty(Exiftool::class, 'toolPath');
         $reflProperty->setAccessible(true);
         $expected = '/foo/bar/baz';
         $reflProperty->setValue($this->adapter, $expected);
@@ -30,11 +30,11 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::setToolPath
+     * @covers Exiftool::setToolPath
      */
     public function testSetToolPathInProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Exiftool', 'toolPath');
+        $reflProperty = new \ReflectionProperty(Exiftool::class, 'toolPath');
         $reflProperty->setAccessible(true);
 
         $expected = '/tmp';
@@ -45,7 +45,7 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::setToolPath
+     * @covers Exiftool::setToolPath
      */
     public function testSetToolPathThrowsException()
     {
@@ -56,7 +56,7 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::getToolPath
+     * @covers Exiftool::getToolPath
      */
     public function testGetToolPathLazyLoadsPath()
     {
@@ -65,11 +65,11 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::setNumeric
+     * @covers Exiftool::setNumeric
      */
     public function testSetNumericInProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Exiftool', 'numeric');
+        $reflProperty = new \ReflectionProperty(Exiftool::class, 'numeric');
         $reflProperty->setAccessible(true);
 
         $expected = true;
@@ -81,11 +81,11 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
     /**
      * @see URI http://www.sno.phy.queensu.ca/~phil/exiftool/faq.html#Q10
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::setEncoding
+     * @covers Exiftool::setEncoding
      */
     public function testSetEncodingInProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Exiftool', 'encoding');
+        $reflProperty = new \ReflectionProperty(Exiftool::class, 'encoding');
         $reflProperty->setAccessible(true);
 
         $expected = array('iptc' => 'cp1250');
@@ -97,7 +97,7 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::getExifFromFile
+     * @covers Exiftool::getExifFromFile
      */
     public function testGetExifFromFile()
     {
@@ -111,7 +111,7 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::getExifFromFile
+     * @covers Exiftool::getExifFromFile
      */
     public function testGetExifFromFileWithUtf8()
     {
@@ -125,11 +125,11 @@ class ExiftoolTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exiftool
-     * @covers \PHPExif\Adapter\Exiftool::getCliOutput
+     * @covers Exiftool::getCliOutput
      */
     public function testGetCliOutput()
     {
-        $reflMethod = new \ReflectionMethod('\PHPExif\Adapter\Exiftool', 'getCliOutput');
+        $reflMethod = new \ReflectionMethod(Exiftool::class, 'getCliOutput');
         $reflMethod->setAccessible(true);
 
         $result = $reflMethod->invoke(

--- a/tests/PHPExif/Adapter/FFprobeTest.php
+++ b/tests/PHPExif/Adapter/FFprobeTest.php
@@ -1,4 +1,8 @@
 <?php
+
+use PHPExif\Adapter\FFprobe;
+use PHPExif\Exif;
+
 /**
  * @covers \PHPExif\Adapter\Native::<!public>
  */
@@ -21,7 +25,7 @@ class FFprobeTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetToolPathFromProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\FFprobe', 'toolPath');
+        $reflProperty = new \ReflectionProperty(FFprobe::class, 'toolPath');
         $reflProperty->setAccessible(true);
         $expected = '/foo/bar/baz';
         $reflProperty->setValue($this->adapter, $expected);
@@ -35,7 +39,7 @@ class FFprobeTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetToolPathInProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\FFprobe', 'toolPath');
+        $reflProperty = new \ReflectionProperty(FFprobe::class, 'toolPath');
         $reflProperty->setAccessible(true);
 
         $expected = '/tmp';
@@ -71,13 +75,13 @@ class FFprobeTest extends \PHPUnit\Framework\TestCase
     {
         $file = PHPEXIF_TEST_ROOT . '/files/IMG_3824.MOV';
         $result = $this->adapter->getExifFromFile($file);
-        $this->assertInstanceOf('\PHPExif\Exif', $result);
+        $this->assertInstanceOf(Exif::class, $result);
         $this->assertIsArray($result->getRawData());
         $this->assertNotEmpty($result->getRawData());
 
         $file = PHPEXIF_TEST_ROOT . '/files/IMG_3825.MOV';
         $result = $this->adapter->getExifFromFile($file);
-        $this->assertInstanceOf('\PHPExif\Exif', $result);
+        $this->assertInstanceOf(Exif::class, $result);
         $this->assertIsArray($result->getRawData());
         $this->assertNotEmpty($result->getRawData());
     }
@@ -88,11 +92,9 @@ class FFprobeTest extends \PHPUnit\Framework\TestCase
      */
     public function testErrorImageUsed()
     {
-        $file = PHPEXIF_TEST_ROOT . '/files/morning_glory_pool_500.jpg';;
-        $result = $this->adapter->getExifFromFile($file);
-        $this->assertIsBool($result);
-        $this->assertEquals(false, $result);
+        $file = PHPEXIF_TEST_ROOT . '/files/morning_glory_pool_500.jpg';
+        $this->expectException(RuntimeException::class);
+        $this->adapter->getExifFromFile($file);
     }
-
 
 }

--- a/tests/PHPExif/Adapter/ImageMagickTest.php
+++ b/tests/PHPExif/Adapter/ImageMagickTest.php
@@ -1,35 +1,39 @@
 <?php
+
+use PHPExif\Adapter\ImageMagick;
+use PHPExif\Exif;
+
 /**
- * @covers \PHPExif\Adapter\ImageMagick::<!public>
+ * @covers ImageMagick::<!public>
  */
 class ImageMagickTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPExif\Adapter\ImageMagick
+     * @var ImageMagick
      */
     protected $adapter;
 
     public function setUp(): void
     {
-        $this->adapter = new \PHPExif\Adapter\ImageMagick();
+        $this->adapter = new ImageMagick();
     }
 
     /**
      * @group ImageMagick
-     * @covers \PHPExif\Adapter\ImageMagick::getExifFromFile
+     * @covers ImageMagick::getExifFromFile
      */
     public function testGetExifFromFile()
     {
         $file = PHPEXIF_TEST_ROOT . '/files/morning_glory_pool_500.jpg';
         $result = $this->adapter->getExifFromFile($file);
-        $this->assertInstanceOf('\PHPExif\Exif', $result);
+        $this->assertInstanceOf(Exif::class, $result);
         $this->assertIsArray($result->getRawData());
         $this->assertNotEmpty($result->getRawData());
     }
 
     /**
      * @group ImageMagick
-     * @covers \PHPExif\Adapter\ImageMagick::getIptcData
+     * @covers ImageMagick::getIptcData
      */
     public function testGetEmptyIptcData()
     {

--- a/tests/PHPExif/Adapter/NativeTest.php
+++ b/tests/PHPExif/Adapter/NativeTest.php
@@ -1,64 +1,67 @@
 <?php
+
+use PHPExif\Adapter\Native;
+
 /**
- * @covers \PHPExif\Adapter\Native::<!public>
+ * @covers Native::<!public>
  */
 class NativeTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPExif\Adapter\Native
+     * @var Native
      */
     protected $adapter;
 
     public function setUp(): void
     {
-        $this->adapter = new \PHPExif\Adapter\Native();
+        $this->adapter = new Native();
     }
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::setIncludeThumbnail
+     * @covers Native::setIncludeThumbnail
      */
     public function testSetIncludeThumbnailInProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Native', 'includeThumbnail');
+        $reflProperty = new \ReflectionProperty(Native::class, 'includeThumbnail');
         $reflProperty->setAccessible(true);
 
-        $this->assertEquals(\PHPExif\Adapter\Native::NO_THUMBNAIL, $reflProperty->getValue($this->adapter));
+        $this->assertEquals(Native::NO_THUMBNAIL, $reflProperty->getValue($this->adapter));
 
-        $this->adapter->setIncludeThumbnail(\PHPExif\Adapter\Native::INCLUDE_THUMBNAIL);
+        $this->adapter->setIncludeThumbnail(Native::INCLUDE_THUMBNAIL);
 
-        $this->assertEquals(\PHPExif\Adapter\Native::INCLUDE_THUMBNAIL, $reflProperty->getValue($this->adapter));
+        $this->assertEquals(Native::INCLUDE_THUMBNAIL, $reflProperty->getValue($this->adapter));
     }
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::getIncludeThumbnail
+     * @covers Native::getIncludeThumbnail
      */
     public function testGetIncludeThumbnailFromProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Native', 'includeThumbnail');
+        $reflProperty = new \ReflectionProperty(Native::class, 'includeThumbnail');
         $reflProperty->setAccessible(true);
-        $reflProperty->setValue($this->adapter, \PHPExif\Adapter\Native::INCLUDE_THUMBNAIL);
+        $reflProperty->setValue($this->adapter, Native::INCLUDE_THUMBNAIL);
 
-        $this->assertEquals(\PHPExif\Adapter\Native::INCLUDE_THUMBNAIL, $this->adapter->getIncludeThumbnail());
+        $this->assertEquals(Native::INCLUDE_THUMBNAIL, $this->adapter->getIncludeThumbnail());
     }
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::GetIncludeThumbnail
+     * @covers Native::GetIncludeThumbnail
      */
     public function testGetIncludeThumbnailHasDefaultValue()
     {
-        $this->assertEquals(\PHPExif\Adapter\Native::NO_THUMBNAIL, $this->adapter->getIncludeThumbnail());
+        $this->assertEquals(Native::NO_THUMBNAIL, $this->adapter->getIncludeThumbnail());
     }
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::getRequiredSections
+     * @covers Native::getRequiredSections
      */
     public function testGetRequiredSections()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Native', 'requiredSections');
+        $reflProperty = new \ReflectionProperty(Native::class, 'requiredSections');
         $reflProperty->setAccessible(true);
 
         $this->assertEquals($reflProperty->getValue($this->adapter), $this->adapter->getRequiredSections());
@@ -66,11 +69,11 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::setRequiredSections
+     * @covers Native::setRequiredSections
      */
     public function testSetRequiredSections()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Native', 'requiredSections');
+        $reflProperty = new \ReflectionProperty(Native::class, 'requiredSections');
         $reflProperty->setAccessible(true);
 
         $testData = array('foo', 'bar', 'baz');
@@ -83,11 +86,11 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::addRequiredSection
+     * @covers Native::addRequiredSection
      */
     public function testAddRequiredSection()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Native', 'requiredSections');
+        $reflProperty = new \ReflectionProperty(Native::class, 'requiredSections');
         $reflProperty->setAccessible(true);
 
         $testData = array('foo', 'bar', 'baz');
@@ -102,7 +105,7 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::getExifFromFile
+     * @covers Native::getExifFromFile
      */
     public function testGetExifFromFileNoData()
     {
@@ -116,7 +119,7 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::getExifFromFile
+     * @covers Native::getExifFromFile
      */
     public function testGetExifFromFileHasData()
     {
@@ -129,7 +132,7 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::getIptcData
+     * @covers Native::getIptcData
      */
     public function testGetIptcData()
     {
@@ -147,7 +150,7 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::getIptcData
+     * @covers Native::getIptcData
      */
     public function testGetEmptyIptcData()
     {
@@ -159,13 +162,13 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::setSectionsAsArrays
+     * @covers Native::setSectionsAsArrays
      */
     public function testSetSectionsAsArrayInProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Native', 'sectionsAsArrays');
+        $reflProperty = new \ReflectionProperty(Native::class, 'sectionsAsArrays');
         $reflProperty->setAccessible(true);
-        $expected = \PHPExif\Adapter\Native::SECTIONS_AS_ARRAYS;
+        $expected = Native::SECTIONS_AS_ARRAYS;
         $this->adapter->setSectionsAsArrays($expected);
         $actual = $reflProperty->getValue($this->adapter);
         $this->assertEquals($expected, $actual);
@@ -173,13 +176,13 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::setSectionsAsArrays
+     * @covers Native::setSectionsAsArrays
      */
     public function testSetSectionsAsArrayConvertsToBoolean()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Native', 'sectionsAsArrays');
+        $reflProperty = new \ReflectionProperty(Native::class, 'sectionsAsArrays');
         $reflProperty->setAccessible(true);
-        $expected = \PHPExif\Adapter\Native::SECTIONS_AS_ARRAYS;
+        $expected = Native::SECTIONS_AS_ARRAYS;
         $this->adapter->setSectionsAsArrays('Foo');
         $actual = $reflProperty->getValue($this->adapter);
         $this->assertEquals($expected, $actual);
@@ -187,14 +190,14 @@ class NativeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group native
-     * @covers \PHPExif\Adapter\Native::getSectionsAsArrays
+     * @covers Native::getSectionsAsArrays
      */
     public function testGetSectionsAsArrayFromProperty()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Adapter\Native', 'sectionsAsArrays');
+        $reflProperty = new \ReflectionProperty(Native::class, 'sectionsAsArrays');
         $reflProperty->setAccessible(true);
-        $reflProperty->setValue($this->adapter, \PHPExif\Adapter\Native::SECTIONS_AS_ARRAYS);
+        $reflProperty->setValue($this->adapter, Native::SECTIONS_AS_ARRAYS);
 
-        $this->assertEquals(\PHPExif\Adapter\Native::SECTIONS_AS_ARRAYS, $this->adapter->getSectionsAsArrays());
+        $this->assertEquals(Native::SECTIONS_AS_ARRAYS, $this->adapter->getSectionsAsArrays());
     }
 }

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -1,11 +1,13 @@
 <?php
+
+use PHPExif\Exif;
 /**
- * @covers \PHPExif\Exif::<!public>
+ * @covers Exif::<!public>
  */
 class ExifTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPExif\Exif
+     * @var Exif
      */
     protected $exif;
 
@@ -14,19 +16,19 @@ class ExifTest extends \PHPUnit\Framework\TestCase
      */
     public function setUp(): void
     {
-        $this->exif = new \PHPExif\Exif();
+        $this->exif = new Exif();
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::__construct
+     * @covers Exif::__construct
      */
     public function testConstructorCallsSetData()
     {
         $input = array();
 
         // Get mock, without the constructor being called
-        $mock = $this->getMockBuilder('\\PHPExif\\Exif')
+        $mock = $this->getMockBuilder(Exif::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -38,18 +40,18 @@ class ExifTest extends \PHPUnit\Framework\TestCase
             );
 
         // now call the constructor
-        $reflectedClass = new ReflectionClass('\\PHPExif\\Exif');
+        $reflectedClass = new ReflectionClass(Exif::class);
         $constructor = $reflectedClass->getConstructor();
         $constructor->invoke($mock, $input);
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getRawData
+     * @covers Exif::getRawData
      */
     public function testGetRawData()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Exif', 'rawData');
+        $reflProperty = new \ReflectionProperty(Exif::class, 'rawData');
         $reflProperty->setAccessible(true);
 
         $this->assertEquals($reflProperty->getValue($this->exif), $this->exif->getRawData());
@@ -57,12 +59,12 @@ class ExifTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::setRawData
+     * @covers Exif::setRawData
      */
     public function testSetRawData()
     {
         $testData = array('foo', 'bar', 'baz');
-        $reflProperty = new \ReflectionProperty('\PHPExif\Exif', 'rawData');
+        $reflProperty = new \ReflectionProperty(Exif::class, 'rawData');
         $reflProperty->setAccessible(true);
 
         $result = $this->exif->setRawData($testData);
@@ -73,11 +75,11 @@ class ExifTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getData
+     * @covers Exif::getData
      */
     public function testGetData()
     {
-        $reflProperty = new \ReflectionProperty('\PHPExif\Exif', 'data');
+        $reflProperty = new \ReflectionProperty(Exif::class, 'data');
         $reflProperty->setAccessible(true);
 
         $this->assertEquals($reflProperty->getValue($this->exif), $this->exif->getData());
@@ -85,12 +87,12 @@ class ExifTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::setData
+     * @covers Exif::setData
      */
     public function testSetData()
     {
         $testData = array('foo', 'bar', 'baz');
-        $reflProperty = new \ReflectionProperty('\PHPExif\Exif', 'data');
+        $reflProperty = new \ReflectionProperty(Exif::class, 'data');
         $reflProperty->setAccessible(true);
 
         $result = $this->exif->setData($testData);
@@ -102,49 +104,49 @@ class ExifTest extends \PHPUnit\Framework\TestCase
     /**
      *
      * @dataProvider providerUndefinedPropertiesReturnFalse
-     * @covers \PHPExif\Exif::getAperture
-     * @covers \PHPExif\Exif::getIso
-     * @covers \PHPExif\Exif::getExposure
-     * @covers \PHPExif\Exif::getExposureMilliseconds
-     * @covers \PHPExif\Exif::getFocusDistance
-     * @covers \PHPExif\Exif::getWidth
-     * @covers \PHPExif\Exif::getHeight
-     * @covers \PHPExif\Exif::getTitle
-     * @covers \PHPExif\Exif::getCaption
-     * @covers \PHPExif\Exif::getCopyright
-     * @covers \PHPExif\Exif::getKeywords
-     * @covers \PHPExif\Exif::getCamera
-     * @covers \PHPExif\Exif::getHorizontalResolution
-     * @covers \PHPExif\Exif::getVerticalResolution
-     * @covers \PHPExif\Exif::getSoftware
-     * @covers \PHPExif\Exif::getFocalLength
-     * @covers \PHPExif\Exif::getCreationDate
-     * @covers \PHPExif\Exif::getAuthor
-     * @covers \PHPExif\Exif::getCredit
-     * @covers \PHPExif\Exif::getSource
-     * @covers \PHPExif\Exif::getJobtitle
-     * @covers \PHPExif\Exif::getMimeType
-     * @covers \PHPExif\Exif::getFileSize
-     * @covers \PHPExif\Exif::getFileName
-     * @covers \PHPExif\Exif::getHeadline
-     * @covers \PHPExif\Exif::getColorSpace
-     * @covers \PHPExif\Exif::getOrientation
-     * @covers \PHPExif\Exif::getGPS
-     * @covers \PHPExif\Exif::getDescription
-     * @covers \PHPExif\Exif::getMake
-     * @covers \PHPExif\Exif::getAltitude
-     * @covers \PHPExif\Exif::getLatitude
-     * @covers \PHPExif\Exif::getLongitude
-     * @covers \PHPExif\Exif::getImgDirection
-     * @covers \PHPExif\Exif::getLens
-     * @covers \PHPExif\Exif::getContentIdentifier
-     * @covers \PHPExif\Exif::getFramerate
-     * @covers \PHPExif\Exif::getDuration
-     * @covers \PHPExif\Exif::getMicroVideoOffset
-     * @covers \PHPExif\Exif::getCity
-     * @covers \PHPExif\Exif::getSublocation
-     * @covers \PHPExif\Exif::getState
-     * @covers \PHPExif\Exif::getCountry
+     * @covers Exif::getAperture
+     * @covers Exif::getIso
+     * @covers Exif::getExposure
+     * @covers Exif::getExposureMilliseconds
+     * @covers Exif::getFocusDistance
+     * @covers Exif::getWidth
+     * @covers Exif::getHeight
+     * @covers Exif::getTitle
+     * @covers Exif::getCaption
+     * @covers Exif::getCopyright
+     * @covers Exif::getKeywords
+     * @covers Exif::getCamera
+     * @covers Exif::getHorizontalResolution
+     * @covers Exif::getVerticalResolution
+     * @covers Exif::getSoftware
+     * @covers Exif::getFocalLength
+     * @covers Exif::getCreationDate
+     * @covers Exif::getAuthor
+     * @covers Exif::getCredit
+     * @covers Exif::getSource
+     * @covers Exif::getJobtitle
+     * @covers Exif::getMimeType
+     * @covers Exif::getFileSize
+     * @covers Exif::getFileName
+     * @covers Exif::getHeadline
+     * @covers Exif::getColorSpace
+     * @covers Exif::getOrientation
+     * @covers Exif::getGPS
+     * @covers Exif::getDescription
+     * @covers Exif::getMake
+     * @covers Exif::getAltitude
+     * @covers Exif::getLatitude
+     * @covers Exif::getLongitude
+     * @covers Exif::getImgDirection
+     * @covers Exif::getLens
+     * @covers Exif::getContentIdentifier
+     * @covers Exif::getFramerate
+     * @covers Exif::getDuration
+     * @covers Exif::getMicroVideoOffset
+     * @covers Exif::getCity
+     * @covers Exif::getSublocation
+     * @covers Exif::getState
+     * @covers Exif::getCountry
      * @param string $accessor
      */
     public function testUndefinedPropertiesReturnFalse($accessor)
@@ -210,12 +212,12 @@ class ExifTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getAperture
+     * @covers Exif::getAperture
      */
     public function testGetAperture()
     {
         $expected = 'f/8.0';
-        $data[\PHPExif\Exif::APERTURE] = $expected;
+        $data[Exif::APERTURE] = $expected;
         $this->exif->setData($data);
 
         $this->assertEquals($expected, $this->exif->getAperture());
@@ -223,31 +225,31 @@ class ExifTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getIso
+     * @covers Exif::getIso
      */
     public function testGetIso()
     {
         $expected = 200;
-        $data[\PHPExif\Exif::ISO] = $expected;
+        $data[Exif::ISO] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getIso());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getExposure
+     * @covers Exif::getExposure
      */
     public function testGetExposure()
     {
         $expected = '1/320';
-        $data[\PHPExif\Exif::EXPOSURE] = $expected;
+        $data[Exif::EXPOSURE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getExposure());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getExposureMilliseconds
+     * @covers Exif::getExposureMilliseconds
      */
     public function testGetExposureMilliseconds()
     {
@@ -260,7 +262,7 @@ class ExifTest extends \PHPUnit\Framework\TestCase
             $expected = reset($data);
             $value = end($data);
 
-            $data[\PHPExif\Exif::EXPOSURE] = $value;
+            $data[Exif::EXPOSURE] = $value;
             $this->exif->setData($data);
             $this->assertEquals($expected, $this->exif->getExposureMilliseconds());
         }
@@ -268,517 +270,517 @@ class ExifTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getFocusDistance
+     * @covers Exif::getFocusDistance
      */
     public function testGetFocusDistance()
     {
         $expected = '7.94m';
-        $data[\PHPExif\Exif::FOCAL_DISTANCE] = $expected;
+        $data[Exif::FOCAL_DISTANCE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getFocusDistance());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getWidth
+     * @covers Exif::getWidth
      */
     public function testGetWidth()
     {
         $expected = 500;
-        $data[\PHPExif\Exif::WIDTH] = $expected;
+        $data[Exif::WIDTH] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getWidth());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getHeight
+     * @covers Exif::getHeight
      */
     public function testGetHeight()
     {
         $expected = 332;
-        $data[\PHPExif\Exif::HEIGHT] = $expected;
+        $data[Exif::HEIGHT] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getHeight());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getTitle
+     * @covers Exif::getTitle
      */
     public function testGetTitle()
     {
         $expected = 'Morning Glory Pool';
-        $data[\PHPExif\Exif::TITLE] = $expected;
+        $data[Exif::TITLE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getTitle());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getCaption
+     * @covers Exif::getCaption
      */
     public function testGetCaption()
     {
         $expected = 'Foo Bar Baz';
-        $data[\PHPExif\Exif::CAPTION] = $expected;
+        $data[Exif::CAPTION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getCaption());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getCopyright
+     * @covers Exif::getCopyright
      */
     public function testGetCopyright()
     {
         $expected = 'Miljar';
-        $data[\PHPExif\Exif::COPYRIGHT] = $expected;
+        $data[Exif::COPYRIGHT] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getCopyright());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getKeywords
+     * @covers Exif::getKeywords
      */
     public function testGetKeywords()
     {
         $expected = array('18-200', 'D90', 'USA', 'Wyoming', 'Yellowstone');
-        $data[\PHPExif\Exif::KEYWORDS] = $expected;
+        $data[Exif::KEYWORDS] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getKeywords());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getCamera
+     * @covers Exif::getCamera
      */
     public function testGetCamera()
     {
         $expected = 'NIKON D90';
-        $data[\PHPExif\Exif::CAMERA] = $expected;
+        $data[Exif::CAMERA] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getCamera());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getHorizontalResolution
+     * @covers Exif::getHorizontalResolution
      */
     public function testGetHorizontalResolution()
     {
         $expected = 240;
-        $data[\PHPExif\Exif::HORIZONTAL_RESOLUTION] = $expected;
+        $data[Exif::HORIZONTAL_RESOLUTION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getHorizontalResolution());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getVerticalResolution
+     * @covers Exif::getVerticalResolution
      */
     public function testGetVerticalResolution()
     {
         $expected = 240;
-        $data[\PHPExif\Exif::VERTICAL_RESOLUTION] = $expected;
+        $data[Exif::VERTICAL_RESOLUTION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getVerticalResolution());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getSoftware
+     * @covers Exif::getSoftware
      */
     public function testGetSoftware()
     {
         $expected = 'Adobe Photoshop Lightroom';
-        $data[\PHPExif\Exif::SOFTWARE] = $expected;
+        $data[Exif::SOFTWARE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getSoftware());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getFocalLength
+     * @covers Exif::getFocalLength
      */
     public function testGetFocalLength()
     {
         $expected = 18;
-        $data[\PHPExif\Exif::FOCAL_LENGTH] = $expected;
+        $data[Exif::FOCAL_LENGTH] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getFocalLength());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getCreationDate
+     * @covers Exif::getCreationDate
      */
     public function testGetCreationDate()
     {
         $expected = '2011-06-07 20:01:50';
         $input = \DateTime::createFromFormat('Y-m-d H:i:s', $expected);
-        $data[\PHPExif\Exif::CREATION_DATE] = $input;
+        $data[Exif::CREATION_DATE] = $input;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getCreationDate()->format('Y-m-d H:i:s'));
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getAuthor
+     * @covers Exif::getAuthor
      */
     public function testGetAuthor()
     {
         $expected = 'John Smith';
-        $data[\PHPExif\Exif::AUTHOR] = $expected;
+        $data[Exif::AUTHOR] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getAuthor());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getHeadline
+     * @covers Exif::getHeadline
      */
     public function testGetHeadline()
     {
         $expected = 'Foobar Baz';
-        $data[\PHPExif\Exif::HEADLINE] = $expected;
+        $data[Exif::HEADLINE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getHeadline());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getCredit
+     * @covers Exif::getCredit
      */
     public function testGetCredit()
     {
         $expected = 'john.smith@example.com';
-        $data[\PHPExif\Exif::CREDIT] = $expected;
+        $data[Exif::CREDIT] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getCredit());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getSource
+     * @covers Exif::getSource
      */
     public function testGetSource()
     {
         $expected = 'FBB NEWS';
-        $data[\PHPExif\Exif::SOURCE] = $expected;
+        $data[Exif::SOURCE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getSource());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getJobtitle
+     * @covers Exif::getJobtitle
      */
     public function testGetJobtitle()
     {
         $expected = 'Yellowstone\'s geysers and pools';
-        $data[\PHPExif\Exif::JOB_TITLE] = $expected;
+        $data[Exif::JOB_TITLE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getJobtitle());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getColorSpace
+     * @covers Exif::getColorSpace
      */
     public function testGetColorSpace()
     {
         $expected = 'RGB';
-        $data[\PHPExif\Exif::COLORSPACE] = $expected;
+        $data[Exif::COLORSPACE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getColorSpace());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getMimeType
+     * @covers Exif::getMimeType
      */
     public function testGetMimeType()
     {
         $expected = 'image/jpeg';
-        $data[\PHPExif\Exif::MIMETYPE] = $expected;
+        $data[Exif::MIMETYPE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getMimeType());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getFileSize
+     * @covers Exif::getFileSize
      */
     public function testGetFileSize()
     {
         $expected = '27852365';
-        $data[\PHPExif\Exif::FILESIZE] = $expected;
+        $data[Exif::FILESIZE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getFileSize());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getFileName
+     * @covers Exif::getFileName
      */
     public function testGetFileName()
     {
         $expected = '27852365.jpg';
-        $data[\PHPExif\Exif::FILENAME] = $expected;
+        $data[Exif::FILENAME] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getFileName());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getOrientation
+     * @covers Exif::getOrientation
      */
     public function testGetOrientation()
     {
         $expected = 1;
-        $data[\PHPExif\Exif::ORIENTATION] = $expected;
+        $data[Exif::ORIENTATION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getOrientation());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getGPS
+     * @covers Exif::getGPS
      */
     public function testGetGPS()
     {
         $expected = '40.333452380556,-20.167314813889';
-        $data[\PHPExif\Exif::GPS] = $expected;
+        $data[Exif::GPS] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getGPS());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getDescription
+     * @covers Exif::getDescription
      */
     public function testGetDescription()
     {
         $expected = 'Lorem ipsum';
-        $data[\PHPExif\Exif::DESCRIPTION] = $expected;
+        $data[Exif::DESCRIPTION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getDescription());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getMake
+     * @covers Exif::getMake
      */
     public function testGetMake()
     {
         $expected = 'Make';
-        $data[\PHPExif\Exif::MAKE] = $expected;
+        $data[Exif::MAKE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getMake());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getAltitude
+     * @covers Exif::getAltitude
      */
     public function testGetAltitude()
     {
         $expected = '8848';
-        $data[\PHPExif\Exif::ALTITUDE] = $expected;
+        $data[Exif::ALTITUDE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getAltitude());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getLatitude
+     * @covers Exif::getLatitude
      */
     public function testGetLatitude()
     {
         $expected = '40.333452380556';
-        $data[\PHPExif\Exif::LATITUDE] = $expected;
+        $data[Exif::LATITUDE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getLatitude());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getLongitude
+     * @covers Exif::getLongitude
      */
     public function testGetLongitude()
     {
         $expected = '-20.167314813889';
-        $data[\PHPExif\Exif::LONGITUDE] = $expected;
+        $data[Exif::LONGITUDE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getLongitude());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getImgDirection
+     * @covers Exif::getImgDirection
      */
     public function testGetImgDirection()
     {
         $expected = '180';
-        $data[\PHPExif\Exif::IMGDIRECTION] = $expected;
+        $data[Exif::IMGDIRECTION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getImgDirection());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getLens
+     * @covers Exif::getLens
      */
     public function testGetLens()
     {
         $expected = '70 - 200mm';
-        $data[\PHPExif\Exif::LENS] = $expected;
+        $data[Exif::LENS] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getLens());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getContentIdentifier
+     * @covers Exif::getContentIdentifier
      */
     public function testGetContentIdentifier()
     {
         $expected = 'C09DCB26-D321-4254-9F68-2E2E7FA16155';
-        $data[\PHPExif\Exif::CONTENTIDENTIFIER] = $expected;
+        $data[Exif::CONTENTIDENTIFIER] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getContentIdentifier());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getFramerate
+     * @covers Exif::getFramerate
      */
     public function testGetFramerate()
     {
         $expected = '24';
-        $data[\PHPExif\Exif::FRAMERATE] = $expected;
+        $data[Exif::FRAMERATE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getFramerate());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getDuration
+     * @covers Exif::getDuration
      */
     public function testGetDuration()
     {
         $expected = '1s';
-        $data[\PHPExif\Exif::DURATION] = $expected;
+        $data[Exif::DURATION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getDuration());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getMicroVideoOffset
+     * @covers Exif::getMicroVideoOffset
      */
     public function testGetMicroVideoOffset()
     {
         $expected = '3062730';
-        $data[\PHPExif\Exif::MICROVIDEOOFFSET] = $expected;
+        $data[Exif::MICROVIDEOOFFSET] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getMicroVideoOffset());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getCity
+     * @covers Exif::getCity
      */
     public function testGetCity()
     {
         $expected = 'New York';
-        $data[\PHPExif\Exif::CITY] = $expected;
+        $data[Exif::CITY] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getCity());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getSublocation
+     * @covers Exif::getSublocation
      */
     public function testGetSublocation()
     {
         $expected = 'sublocation';
-        $data[\PHPExif\Exif::SUBLOCATION] = $expected;
+        $data[Exif::SUBLOCATION] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getSublocation());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getState
+     * @covers Exif::getState
      */
     public function testGetState()
     {
         $expected = 'New York';
-        $data[\PHPExif\Exif::STATE] = $expected;
+        $data[Exif::STATE] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getState());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::getCountry
+     * @covers Exif::getCountry
      */
     public function testGetCountry()
     {
         $expected = 'USA';
-        $data[\PHPExif\Exif::COUNTRY] = $expected;
+        $data[Exif::COUNTRY] = $expected;
         $this->exif->setData($data);
         $this->assertEquals($expected, $this->exif->getCountry());
     }
 
     /**
      * @group exif
-     * @covers \PHPExif\Exif::setAperture
-     * @covers \PHPExif\Exif::setIso
-     * @covers \PHPExif\Exif::setExposure
-     * @covers \PHPExif\Exif::setFocusDistance
-     * @covers \PHPExif\Exif::setWidth
-     * @covers \PHPExif\Exif::setHeight
-     * @covers \PHPExif\Exif::setTitle
-     * @covers \PHPExif\Exif::setCaption
-     * @covers \PHPExif\Exif::setCopyright
-     * @covers \PHPExif\Exif::setKeywords
-     * @covers \PHPExif\Exif::setCamera
-     * @covers \PHPExif\Exif::setHorizontalResolution
-     * @covers \PHPExif\Exif::setVerticalResolution
-     * @covers \PHPExif\Exif::setSoftware
-     * @covers \PHPExif\Exif::setFocalLength
-     * @covers \PHPExif\Exif::setCreationDate
-     * @covers \PHPExif\Exif::setAuthor
-     * @covers \PHPExif\Exif::setCredit
-     * @covers \PHPExif\Exif::setSource
-     * @covers \PHPExif\Exif::setJobtitle
-     * @covers \PHPExif\Exif::setMimeType
-     * @covers \PHPExif\Exif::setFileSize
-     * @covers \PHPExif\Exif::setFileName
-     * @covers \PHPExif\Exif::setHeadline
-     * @covers \PHPExif\Exif::setColorSpace
-     * @covers \PHPExif\Exif::setOrientation
-     * @covers \PHPExif\Exif::setGPS
-     * @covers \PHPExif\Exif::setDescription
-     * @covers \PHPExif\Exif::setMake
-     * @covers \PHPExif\Exif::setAltitude
-     * @covers \PHPExif\Exif::setLongitude
-     * @covers \PHPExif\Exif::setLatitude
-     * @covers \PHPExif\Exif::setImgDirection
-     * @covers \PHPExif\Exif::setLens
-     * @covers \PHPExif\Exif::setContentIdentifier
-     * @covers \PHPExif\Exif::setFramerate
-     * @covers \PHPExif\Exif::setDuration
-     * @covers \PHPExif\Exif::setMicroVideoOffset
-     * @covers \PHPExif\Exif::setCity
-     * @covers \PHPExif\Exif::setSublocation
-     * @covers \PHPExif\Exif::setState
-     * @covers \PHPExif\Exif::setCountry
+     * @covers Exif::setAperture
+     * @covers Exif::setIso
+     * @covers Exif::setExposure
+     * @covers Exif::setFocusDistance
+     * @covers Exif::setWidth
+     * @covers Exif::setHeight
+     * @covers Exif::setTitle
+     * @covers Exif::setCaption
+     * @covers Exif::setCopyright
+     * @covers Exif::setKeywords
+     * @covers Exif::setCamera
+     * @covers Exif::setHorizontalResolution
+     * @covers Exif::setVerticalResolution
+     * @covers Exif::setSoftware
+     * @covers Exif::setFocalLength
+     * @covers Exif::setCreationDate
+     * @covers Exif::setAuthor
+     * @covers Exif::setCredit
+     * @covers Exif::setSource
+     * @covers Exif::setJobtitle
+     * @covers Exif::setMimeType
+     * @covers Exif::setFileSize
+     * @covers Exif::setFileName
+     * @covers Exif::setHeadline
+     * @covers Exif::setColorSpace
+     * @covers Exif::setOrientation
+     * @covers Exif::setGPS
+     * @covers Exif::setDescription
+     * @covers Exif::setMake
+     * @covers Exif::setAltitude
+     * @covers Exif::setLongitude
+     * @covers Exif::setLatitude
+     * @covers Exif::setImgDirection
+     * @covers Exif::setLens
+     * @covers Exif::setContentIdentifier
+     * @covers Exif::setFramerate
+     * @covers Exif::setDuration
+     * @covers Exif::setMicroVideoOffset
+     * @covers Exif::setCity
+     * @covers Exif::setSublocation
+     * @covers Exif::setState
+     * @covers Exif::setCountry
      */
     public function testMutatorMethodsSetInProperty()
     {
@@ -836,33 +838,33 @@ class ExifTest extends \PHPUnit\Framework\TestCase
      * Test that the values returned by different adapters are equal
      *
      * @group consistency
-     * @covers \PHPExif\Exif::getAperture
-     * @covers \PHPExif\Exif::getIso
-     * @covers \PHPExif\Exif::getExposure
-     * @covers \PHPExif\Exif::getExposureMilliseconds
-     * @covers \PHPExif\Exif::getFocusDistance
-     * @covers \PHPExif\Exif::getWidth
-     * @covers \PHPExif\Exif::getHeight
-     * @covers \PHPExif\Exif::getTitle
-     * @covers \PHPExif\Exif::getCaption
-     * @covers \PHPExif\Exif::getCopyright
-     * @covers \PHPExif\Exif::getKeywords
-     * @covers \PHPExif\Exif::getCamera
-     * @covers \PHPExif\Exif::getHorizontalResolution
-     * @covers \PHPExif\Exif::getVerticalResolution
-     * @covers \PHPExif\Exif::getSoftware
-     * @covers \PHPExif\Exif::getFocalLength
-     * @covers \PHPExif\Exif::getCreationDate
-     * @covers \PHPExif\Exif::getAuthor
-     * @covers \PHPExif\Exif::getCredit
-     * @covers \PHPExif\Exif::getSource
-     * @covers \PHPExif\Exif::getJobtitle
-     * @covers \PHPExif\Exif::getMimeType
-     * @covers \PHPExif\Exif::getFileSize
+     * @covers Exif::getAperture
+     * @covers Exif::getIso
+     * @covers Exif::getExposure
+     * @covers Exif::getExposureMilliseconds
+     * @covers Exif::getFocusDistance
+     * @covers Exif::getWidth
+     * @covers Exif::getHeight
+     * @covers Exif::getTitle
+     * @covers Exif::getCaption
+     * @covers Exif::getCopyright
+     * @covers Exif::getKeywords
+     * @covers Exif::getCamera
+     * @covers Exif::getHorizontalResolution
+     * @covers Exif::getVerticalResolution
+     * @covers Exif::getSoftware
+     * @covers Exif::getFocalLength
+     * @covers Exif::getCreationDate
+     * @covers Exif::getAuthor
+     * @covers Exif::getCredit
+     * @covers Exif::getSource
+     * @covers Exif::getJobtitle
+     * @covers Exif::getMimeType
+     * @covers Exif::getFileSize
      */
     public function testAdapterConsistency()
     {
-        $reflClass = new \ReflectionClass('\PHPExif\Exif');
+        $reflClass = new \ReflectionClass(Exif::class);
         $methods = $reflClass->getMethods(ReflectionMethod::IS_PUBLIC);
         $testfiles = array(
             PHPEXIF_TEST_ROOT . '/files/morning_glory_pool_500.jpg',

--- a/tests/PHPExif/Hydrator/MutatorTest.php
+++ b/tests/PHPExif/Hydrator/MutatorTest.php
@@ -1,6 +1,9 @@
 <?php
+
+use PhpExif\Hydrator\Mutator;
+
 /**
- * @covers \PHPExif\Hydrator\Mutator::<!public>
+ * @covers Mutator::<!public>
  */
 class MutatorTest extends \PHPUnit\Framework\TestCase
 {
@@ -13,7 +16,7 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group hydrator
-     * @covers \PHPExif\Hydrator\Mutator::hydrate
+     * @covers Mutator::hydrate
      */
     public function testHydrateCallsDetermineMutator()
     {
@@ -23,8 +26,8 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
         );
 
         // create mock
-        $mock = $this->getMockBuilder('\\PHPExif\\Hydrator\\Mutator')
-            ->setMethods(array('determineMutator'))
+        $mock = $this->getMockBuilder(Mutator::class)
+            ->onlyMethods(array('determineMutator'))
             ->getMock();
 
         $mock->expects($this->exactly(count($input)))
@@ -39,7 +42,7 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group hydrator
-     * @covers \PHPExif\Hydrator\Mutator::hydrate
+     * @covers Mutator::hydrate
      */
     public function testHydrateCallsMutatorsOnObject()
     {
@@ -58,13 +61,13 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo($input['bar']));
 
         // do the test
-        $hydrator = new \PHPExif\Hydrator\Mutator;
+        $hydrator = new Mutator;
         $hydrator->hydrate($mock, $input);
     }
 
     /**
      * @group hydrator
-     * @covers \PHPExif\Hydrator\Mutator::hydrate
+     * @covers Mutator::hydrate
      */
     public function testHydrateCallsEmptyValues()
     {
@@ -76,7 +79,7 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
 
         // create mock
         $mock = $this->getMockBuilder('TestClass')
-            ->setMethods(array('setFoo', 'setBar'))
+            ->onlyMethods(array('setFoo', 'setBar'))
             ->getMock();
 
         $mock->expects($this->exactly(0))
@@ -85,7 +88,7 @@ class MutatorTest extends \PHPUnit\Framework\TestCase
             ->method('setBar');
 
         // do the test
-        $hydrator = new \PHPExif\Hydrator\Mutator;
+        $hydrator = new Mutator;
         $hydrator->hydrate($mock, $input);
     }
 }

--- a/tests/PHPExif/Mapper/ExiftoolMapperTest.php
+++ b/tests/PHPExif/Mapper/ExiftoolMapperTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use PHPExif\Contracts\MapperInterface;
+use PhpExif\Mapper\Exiftool;
 
 /**
- * @covers \PHPExif\Mapper\Exiftool::<!public>
+ * @covers Exiftool::<!public>
  */
 class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 {
@@ -11,7 +12,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        $this->mapper = new \PHPExif\Mapper\Exiftool;
+        $this->mapper = new Exiftool;
     }
 
     /**
@@ -24,7 +25,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataIgnoresFieldIfItDoesntExist()
     {
@@ -36,7 +37,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataMapsFieldsCorrectly()
     {
@@ -45,56 +46,56 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
         $map = $reflProp->getValue($this->mapper);
 
         // ignore custom formatted data stuff:
-        unset($map[\PHPExif\Mapper\Exiftool::APERTURE]);
-        unset($map[\PHPExif\Mapper\Exiftool::APPROXIMATEFOCUSDISTANCE]);
-        unset($map[\PHPExif\Mapper\Exiftool::COPYRIGHT_IPTC]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL]);
-        unset($map[\PHPExif\Mapper\Exiftool::EXPOSURETIME]);
-        unset($map[\PHPExif\Mapper\Exiftool::FOCALLENGTH]);
-        unset($map[\PHPExif\Mapper\Exiftool::GPSLATITUDE]);
-        unset($map[\PHPExif\Mapper\Exiftool::GPSLONGITUDE]);
-        unset($map[\PHPExif\Mapper\Exiftool::CAPTIONABSTRACT]);
-        unset($map[\PHPExif\Mapper\Exiftool::TITLE]);
-        unset($map[\PHPExif\Mapper\Exiftool::DESCRIPTION_XMP]);
-        unset($map[\PHPExif\Mapper\Exiftool::CONTENTIDENTIFIER]);
-        unset($map[\PHPExif\Mapper\Exiftool::KEYWORDS]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_QUICKTIME]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_AVI]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_WEBM]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_OGG]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_WMV]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_APPLE]);
-        unset($map[\PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_PNG]);
-        unset($map[\PHPExif\Mapper\Exiftool::MAKE_QUICKTIME]);
-        unset($map[\PHPExif\Mapper\Exiftool::MODEL_QUICKTIME]);
-        unset($map[\PHPExif\Mapper\Exiftool::FRAMERATE]);
-        unset($map[\PHPExif\Mapper\Exiftool::FRAMERATE_QUICKTIME_1]);
-        unset($map[\PHPExif\Mapper\Exiftool::FRAMERATE_QUICKTIME_2]);
-        unset($map[\PHPExif\Mapper\Exiftool::FRAMERATE_QUICKTIME_3]);
-        unset($map[\PHPExif\Mapper\Exiftool::FRAMERATE_AVI]);
-        unset($map[\PHPExif\Mapper\Exiftool::FRAMERATE_OGG]);
-        unset($map[\PHPExif\Mapper\Exiftool::DURATION]);
-        unset($map[\PHPExif\Mapper\Exiftool::DURATION_QUICKTIME]);
-        unset($map[\PHPExif\Mapper\Exiftool::DURATION_WEBM]);
-        unset($map[\PHPExif\Mapper\Exiftool::DURATION_WMV]);
-        unset($map[\PHPExif\Mapper\Exiftool::CONTENTIDENTIFIER_KEYS]);
-        unset($map[\PHPExif\Mapper\Exiftool::GPSLATITUDE_QUICKTIME]);
-        unset($map[\PHPExif\Mapper\Exiftool::GPSLONGITUDE_QUICKTIME]);
-        unset($map[\PHPExif\Mapper\Exiftool::GPSALTITUDE_QUICKTIME]);
-        unset($map[\PHPExif\Mapper\Exiftool::MEDIA_GROUP_UUID]);
-        unset($map[\PHPExif\Mapper\Exiftool::MICROVIDEOOFFSET]);
-        unset($map[\PHPExif\Mapper\Exiftool::CITY]);
-        unset($map[\PHPExif\Mapper\Exiftool::SUBLOCATION]);
-        unset($map[\PHPExif\Mapper\Exiftool::STATE]);
-        unset($map[\PHPExif\Mapper\Exiftool::COUNTRY]);
-        unset($map[\PHPExif\Mapper\Exiftool::LENS_ID]);
-        unset($map[\PHPExif\Mapper\Exiftool::LENS]);
-        unset($map[\PHPExif\Mapper\Exiftool::DESCRIPTION]);
-        unset($map[\PHPExif\Mapper\Exiftool::KEYWORDS]);
-        unset($map[\PHPExif\Mapper\Exiftool::SUBJECT]);
-        unset($map[\PHPExif\Mapper\Exiftool::CONTENTIDENTIFIER]);
-        unset($map[\PHPExif\Mapper\Exiftool::CONTENTIDENTIFIER_QUICKTIME]);
+        unset($map[Exiftool::APERTURE]);
+        unset($map[Exiftool::APPROXIMATEFOCUSDISTANCE]);
+        unset($map[Exiftool::COPYRIGHT_IPTC]);
+        unset($map[Exiftool::DATETIMEORIGINAL]);
+        unset($map[Exiftool::EXPOSURETIME]);
+        unset($map[Exiftool::FOCALLENGTH]);
+        unset($map[Exiftool::GPSLATITUDE]);
+        unset($map[Exiftool::GPSLONGITUDE]);
+        unset($map[Exiftool::CAPTIONABSTRACT]);
+        unset($map[Exiftool::TITLE]);
+        unset($map[Exiftool::DESCRIPTION_XMP]);
+        unset($map[Exiftool::CONTENTIDENTIFIER]);
+        unset($map[Exiftool::KEYWORDS]);
+        unset($map[Exiftool::DATETIMEORIGINAL]);
+        unset($map[Exiftool::DATETIMEORIGINAL_QUICKTIME]);
+        unset($map[Exiftool::DATETIMEORIGINAL_AVI]);
+        unset($map[Exiftool::DATETIMEORIGINAL_WEBM]);
+        unset($map[Exiftool::DATETIMEORIGINAL_OGG]);
+        unset($map[Exiftool::DATETIMEORIGINAL_WMV]);
+        unset($map[Exiftool::DATETIMEORIGINAL_APPLE]);
+        unset($map[Exiftool::DATETIMEORIGINAL_PNG]);
+        unset($map[Exiftool::MAKE_QUICKTIME]);
+        unset($map[Exiftool::MODEL_QUICKTIME]);
+        unset($map[Exiftool::FRAMERATE]);
+        unset($map[Exiftool::FRAMERATE_QUICKTIME_1]);
+        unset($map[Exiftool::FRAMERATE_QUICKTIME_2]);
+        unset($map[Exiftool::FRAMERATE_QUICKTIME_3]);
+        unset($map[Exiftool::FRAMERATE_AVI]);
+        unset($map[Exiftool::FRAMERATE_OGG]);
+        unset($map[Exiftool::DURATION]);
+        unset($map[Exiftool::DURATION_QUICKTIME]);
+        unset($map[Exiftool::DURATION_WEBM]);
+        unset($map[Exiftool::DURATION_WMV]);
+        unset($map[Exiftool::CONTENTIDENTIFIER_KEYS]);
+        unset($map[Exiftool::GPSLATITUDE_QUICKTIME]);
+        unset($map[Exiftool::GPSLONGITUDE_QUICKTIME]);
+        unset($map[Exiftool::GPSALTITUDE_QUICKTIME]);
+        unset($map[Exiftool::MEDIA_GROUP_UUID]);
+        unset($map[Exiftool::MICROVIDEOOFFSET]);
+        unset($map[Exiftool::CITY]);
+        unset($map[Exiftool::SUBLOCATION]);
+        unset($map[Exiftool::STATE]);
+        unset($map[Exiftool::COUNTRY]);
+        unset($map[Exiftool::LENS_ID]);
+        unset($map[Exiftool::LENS]);
+        unset($map[Exiftool::DESCRIPTION]);
+        unset($map[Exiftool::KEYWORDS]);
+        unset($map[Exiftool::SUBJECT]);
+        unset($map[Exiftool::CONTENTIDENTIFIER]);
+        unset($map[Exiftool::CONTENTIDENTIFIER_QUICKTIME]);
 
         // create raw data
         $keys = array_keys($map);
@@ -114,12 +115,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsAperture()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::APERTURE => 0.123,
+            Exiftool::APERTURE => 0.123,
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -129,12 +130,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsFocusDistance()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::APPROXIMATEFOCUSDISTANCE => 50,
+            Exiftool::APPROXIMATEFOCUSDISTANCE => 50,
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -144,12 +145,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDate()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -164,21 +165,21 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDateWithTimeZone()
     {
         $data = array(
           array(
-            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09+0200',
+            Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09+0200',
           ),
           array(
-              \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+              Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
               'ExifIFD:OffsetTimeOriginal' => '+0200',
           ),
           array(
-              \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_APPLE => '2015-04-01T12:11:09+0200',
-              \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+              Exiftool::DATETIMEORIGINAL_APPLE => '2015-04-01T12:11:09+0200',
+              Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
               'ExifIFD:OffsetTimeOriginal' => '+0200',
           )
         );
@@ -205,12 +206,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDateWithTimeZone2()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
             'ExifIFD:OffsetTimeOriginal' => '+0200',
         );
 
@@ -234,12 +235,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectCreationDate()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2015:04:01',
+            Exiftool::DATETIMEORIGINAL => '2015:04:01',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -249,12 +250,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectCreationDate2()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL_APPLE => '2015:04:01',
+            Exiftool::DATETIMEORIGINAL_APPLE => '2015:04:01',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -264,12 +265,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectTimeZone()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            Exiftool::DATETIMEORIGINAL => '2015:04:01 12:11:09',
             'ExifIFD:OffsetTimeOriginal' => '   :  ',
         );
 
@@ -285,7 +286,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
@@ -298,7 +299,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
         foreach ($rawData as $expected => $value) {
             $mapped = $this->mapper->mapRawData(array(
-                \PHPExif\Mapper\Exiftool::EXPOSURETIME => $value,
+                Exiftool::EXPOSURETIME => $value,
             ));
 
             $this->assertEquals($expected, reset($mapped));
@@ -307,12 +308,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsFocalLength()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::FOCALLENGTH => '15 m',
+            Exiftool::FOCALLENGTH => '15 m',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -322,16 +323,16 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsGPSData()
     {
         $this->mapper->setNumeric(false);
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSLATITUDE  => '40 deg 20\' 0.42857" N',
+                Exiftool::GPSLATITUDE  => '40 deg 20\' 0.42857" N',
                 'GPS:GPSLatitudeRef'                   => 'North',
-                \PHPExif\Mapper\Exiftool::GPSLONGITUDE => '20 deg 10\' 2.33333" W',
+                Exiftool::GPSLONGITUDE => '20 deg 10\' 2.33333" W',
                 'GPS:GPSLongitudeRef'                  => 'West',
             )
         );
@@ -347,16 +348,16 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataIncorrectlyFormatedGPSData()
     {
         $this->mapper->setNumeric(false);
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSLATITUDE  => '40 degrees 20\' 0.42857" N',
+                Exiftool::GPSLATITUDE  => '40 degrees 20\' 0.42857" N',
                 'GPS:GPSLatitudeRef'                   => 'North',
-                \PHPExif\Mapper\Exiftool::GPSLONGITUDE => '20 degrees 10\' 2.33333" W',
+                Exiftool::GPSLONGITUDE => '20 degrees 10\' 2.33333" W',
                 'GPS:GPSLongitudeRef'                  => 'West',
             )
         );
@@ -366,15 +367,15 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsNumericGPSData()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSLATITUDE  => '40.333452381',
+                Exiftool::GPSLATITUDE  => '40.333452381',
                 'GPS:GPSLatitudeRef'                   => 'North',
-                \PHPExif\Mapper\Exiftool::GPSLONGITUDE => '20.167314814',
+                Exiftool::GPSLONGITUDE => '20.167314814',
                 'GPS:GPSLongitudeRef'                  => 'West',
             )
         );
@@ -390,13 +391,13 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataOnlyLatitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSLATITUDE => '40.333452381',
+                Exiftool::GPSLATITUDE => '40.333452381',
                 'GPS:GPSLatitudeRef'                  => 'North',
             )
         );
@@ -406,15 +407,15 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresEmptyGPSData()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSLATITUDE  => '',
+                Exiftool::GPSLATITUDE  => '',
                 'GPS:GPSLatitudeRef'                   => '',
-                \PHPExif\Mapper\Exiftool::GPSLONGITUDE => '',
+                Exiftool::GPSLONGITUDE => '',
                 'GPS:GPSLongitudeRef'                  => '',
             )
         );
@@ -424,12 +425,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectImageDirection()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::IMGDIRECTION => 'undef',
+            Exiftool::IMGDIRECTION => 'undef',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -439,12 +440,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectImageDirection()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::IMGDIRECTION => '180.0',
+            Exiftool::IMGDIRECTION => '180.0',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -454,7 +455,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::setNumeric
+     * @covers Exiftool::setNumeric
      */
     public function testSetNumericInProperty()
     {
@@ -470,7 +471,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
     public function testMapRawDataCorrectlyFormatsDifferentDateTimeString()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => '2014-12-15 00:12:00'
+            Exiftool::DATETIMEORIGINAL => '2014-12-15 00:12:00'
         );
 
         $mapped = $this->mapper->mapRawData(
@@ -488,7 +489,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
     public function testMapRawDataCorrectlyIgnoresInvalidCreateDate()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::DATETIMEORIGINAL => 'Invalid Date String'
+            Exiftool::DATETIMEORIGINAL => 'Invalid Date String'
         );
 
         $result = $this->mapper->mapRawData(
@@ -504,13 +505,13 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyAltitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSALTITUDE  => '122.053',
+                Exiftool::GPSALTITUDE  => '122.053',
                 'GPS:GPSAltitudeRef'                   => '0',
             )
         );
@@ -520,13 +521,13 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyNegativeAltitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSALTITUDE  => '122.053',
+                Exiftool::GPSALTITUDE  => '122.053',
                 'GPS:GPSAltitudeRef'                   => '1',
             )
         );
@@ -536,13 +537,13 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectAltitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSALTITUDE  => 'undef',
+                Exiftool::GPSALTITUDE  => 'undef',
                 'GPS:GPSAltitudeRef'                   => '0',
             )
         );
@@ -551,15 +552,15 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsQuicktimeGPSData()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSLATITUDE_QUICKTIME  => '40.333',
+                Exiftool::GPSLATITUDE_QUICKTIME  => '40.333',
                 'GPS:GPSLatitudeRef'                             => 'North',
-                \PHPExif\Mapper\Exiftool::GPSLONGITUDE_QUICKTIME => '-20.167',
+                Exiftool::GPSLONGITUDE_QUICKTIME => '-20.167',
                 'GPS:GPSLongitudeRef'                            => 'West',
             )
         );
@@ -574,13 +575,13 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyQuicktimeAltitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\Exiftool::GPSALTITUDE_QUICKTIME  => '122.053',
+                Exiftool::GPSALTITUDE_QUICKTIME  => '122.053',
                 'Composite:GPSAltitudeRef'                       => '1',
             )
         );
@@ -590,36 +591,36 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyHeightVideo()
     {
         $rawData = array(
           '600'  => array(
-                            \PHPExif\Mapper\Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
+                            Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
                         ),
           '600'  => array(
-                            \PHPExif\Mapper\Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
+                            Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
                             'Composite:Rotation'                        => '0',
                         ),
           '800'  => array(
-                            \PHPExif\Mapper\Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
+                            Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
                             'Composite:Rotation'                        => '90',
                        ),
           '800'  => array(
-                            \PHPExif\Mapper\Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
+                            Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
                             'Composite:Rotation'                        => '270',
                         ),
           '600'  => array(
-                            \PHPExif\Mapper\Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
+                            Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
                             'Composite:Rotation'                        => '360',
                         ),
           '600'  => array(
-                            \PHPExif\Mapper\Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
+                            Exiftool::IMAGEHEIGHT_VIDEO  => '800x600',
                             'Composite:Rotation'                        => '180',
                         ),
           '600'  => array(
-                            \PHPExif\Mapper\Exiftool::IMAGEHEIGHT_VIDEO  => '800 600',
+                            Exiftool::IMAGEHEIGHT_VIDEO  => '800 600',
                             'Composite:Rotation'                        => '180',
                         ),
       );
@@ -635,36 +636,36 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyWidthVideo()
     {
         $rawData = array(
               '800'  => array(
-                                \PHPExif\Mapper\Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
+                                Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
                             ),
               '800'  => array(
-                                \PHPExif\Mapper\Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
+                                Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
                                 'Composite:Rotation'                        => '0',
                             ),
               '600'  => array(
-                                \PHPExif\Mapper\Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
+                                Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
                                 'Composite:Rotation'                        => '90',
                             ),
               '600'  => array(
-                                \PHPExif\Mapper\Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
+                                Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
                                 'Composite:Rotation'                        => '270',
                             ),
               '800'  => array(
-                                \PHPExif\Mapper\Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
+                                Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
                                 'Composite:Rotation'                        => '360',
                             ),
               '800'  => array(
-                                \PHPExif\Mapper\Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
+                                Exiftool::IMAGEWIDTH_VIDEO  => '800x600',
                                 'Composite:Rotation'                        => '180',
                             ),
               '800'  => array(
-                                \PHPExif\Mapper\Exiftool::IMAGEWIDTH_VIDEO  => '800 600',
+                                Exiftool::IMAGEWIDTH_VIDEO  => '800 600',
                                 'Composite:Rotation'                        => '180',
                             ),
           );
@@ -679,7 +680,7 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyIsoFormats()
     {
@@ -700,21 +701,21 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyLensData()
     {
         $data = array(
             array(
-                \PHPExif\Mapper\Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
             ),
             array(
-                \PHPExif\Mapper\Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
-                \PHPExif\Mapper\Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
             ),
             array(
-                \PHPExif\Mapper\Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
-                \PHPExif\Mapper\Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                Exiftool::LENS => 'LEICA DG 12-60/F2.8-4.0',
           )
         );
 
@@ -730,12 +731,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyLensData2()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
+            Exiftool::LENS_ID => 'LUMIX G VARIO 12-32/F3.5-5.6',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -748,12 +749,12 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyKeywords()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::KEYWORDS => 'Keyword_1 Keyword_2',
+            Exiftool::KEYWORDS => 'Keyword_1 Keyword_2',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -766,13 +767,13 @@ class ExiftoolMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Exiftool::mapRawData
+     * @covers Exiftool::mapRawData
      */
     public function testMapRawDataCorrectlyKeywordsAndSubject()
     {
         $rawData = array(
-            \PHPExif\Mapper\Exiftool::KEYWORDS => array('Keyword_1', 'Keyword_2'),
-            \PHPExif\Mapper\Exiftool::SUBJECT => array('Keyword_1', 'Keyword_3'),
+            Exiftool::KEYWORDS => array('Keyword_1', 'Keyword_2'),
+            Exiftool::SUBJECT => array('Keyword_1', 'Keyword_3'),
         );
 
         $mapped = $this->mapper->mapRawData($rawData);

--- a/tests/PHPExif/Mapper/FFprobeMapperTest.php
+++ b/tests/PHPExif/Mapper/FFprobeMapperTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use FFMpeg\FFProbe as FFMpegFFProbe;
 use PHPExif\Contracts\MapperInterface;
+use PHPExif\Mapper\FFprobe;
 
 /**
- * @covers \PHPExif\Mapper\FFprobe::<!public>
+ * @covers FFprobe::<!public>
  */
 class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 {
@@ -11,7 +13,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        $this->mapper = new \PHPExif\Mapper\FFprobe;
+        $this->mapper = new FFprobe();
     }
 
     /**
@@ -24,7 +26,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataIgnoresFieldIfItDoesntExist()
     {
@@ -36,7 +38,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataMapsFieldsCorrectly()
     {
@@ -45,24 +47,24 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
         $map = $reflProp->getValue($this->mapper);
 
         // ignore custom formatted data stuff:
-        unset($map[\PHPExif\Mapper\FFprobe::FILESIZE]);
-        unset($map[\PHPExif\Mapper\FFprobe::FILENAME]);
-        unset($map[\PHPExif\Mapper\FFprobe::MIMETYPE]);
-        unset($map[\PHPExif\Mapper\FFprobe::GPSLATITUDE]);
-        unset($map[\PHPExif\Mapper\FFprobe::GPSLONGITUDE]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_GPSALTITUDE]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_GPSLATITUDE]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_GPSLONGITUDE]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_DESCRIPTION]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_MAKE]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_MODEL]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_CONTENTIDENTIFIER]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_DESCRIPTION]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_TITLE]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_DATE]);
-        unset($map[\PHPExif\Mapper\FFprobe::QUICKTIME_KEYWORDS]);
-        unset($map[\PHPExif\Mapper\FFprobe::FRAMERATE]);
-        unset($map[\PHPExif\Mapper\FFprobe::DURATION]);
+        unset($map[FFprobe::FILESIZE]);
+        unset($map[FFprobe::FILENAME]);
+        unset($map[FFprobe::MIMETYPE]);
+        unset($map[FFprobe::GPSLATITUDE]);
+        unset($map[FFprobe::GPSLONGITUDE]);
+        unset($map[FFprobe::QUICKTIME_GPSALTITUDE]);
+        unset($map[FFprobe::QUICKTIME_GPSLATITUDE]);
+        unset($map[FFprobe::QUICKTIME_GPSLONGITUDE]);
+        unset($map[FFprobe::QUICKTIME_DESCRIPTION]);
+        unset($map[FFprobe::QUICKTIME_MAKE]);
+        unset($map[FFprobe::QUICKTIME_MODEL]);
+        unset($map[FFprobe::QUICKTIME_CONTENTIDENTIFIER]);
+        unset($map[FFprobe::QUICKTIME_DESCRIPTION]);
+        unset($map[FFprobe::QUICKTIME_TITLE]);
+        unset($map[FFprobe::QUICKTIME_DATE]);
+        unset($map[FFprobe::QUICKTIME_KEYWORDS]);
+        unset($map[FFprobe::FRAMERATE]);
+        unset($map[FFprobe::DURATION]);
 
         // create raw data
         $keys = array_keys($map);
@@ -81,12 +83,12 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsDateTimeOriginal()
     {
         $rawData = array(
-            \PHPExif\Mapper\FFprobe::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            FFprobe::DATETIMEORIGINAL => '2015:04:01 12:11:09',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -102,13 +104,13 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDateQuicktime()
     {
         $rawData = array(
-            \PHPExif\Mapper\FFprobe::QUICKTIME_DATE => '2015-04-01T12:11:09+0200',
-            \PHPExif\Mapper\FFprobe::DATETIMEORIGINAL => '2015-04-01T12:11:09.000000Z',
+            FFprobe::QUICKTIME_DATE => '2015-04-01T12:11:09+0200',
+            FFprobe::DATETIMEORIGINAL => '2015-04-01T12:11:09.000000Z',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -131,12 +133,12 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDateWithTimeZone()
     {
         $rawData = array(
-            \PHPExif\Mapper\FFprobe::DATETIMEORIGINAL => '2015:04:01 12:11:09+0200',
+            FFprobe::DATETIMEORIGINAL => '2015:04:01 12:11:09+0200',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -159,12 +161,12 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectDateTimeOriginal()
     {
         $rawData = array(
-            \PHPExif\Mapper\FFprobe::DATETIMEORIGINAL => '2015:04:01',
+            FFprobe::DATETIMEORIGINAL => '2015:04:01',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -174,12 +176,12 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectDateTimeOriginal2()
     {
         $rawData = array(
-            \PHPExif\Mapper\FFprobe::QUICKTIME_DATE => '2015:04:01',
+            FFprobe::QUICKTIME_DATE => '2015:04:01',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -189,7 +191,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsQuickTimeGPSData()
     {
@@ -213,7 +215,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyRotatesDimensions()
     {
@@ -235,7 +237,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsGPSData()
     {
@@ -259,7 +261,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     * @covers FFprobe::mapRawData
      */
     public function testMapRawDataCorrectlyFramerate()
     {
@@ -281,7 +283,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
     public function testMapRawDataCorrectlyFormatsDifferentDateTimeString()
     {
         $rawData = array(
-            \PHPExif\Mapper\FFprobe::DATETIMEORIGINAL => '2014-12-15 00:12:00'
+            FFprobe::DATETIMEORIGINAL => '2014-12-15 00:12:00'
         );
 
         $mapped = $this->mapper->mapRawData(
@@ -299,7 +301,7 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
     public function testMapRawDataCorrectlyIgnoresInvalidCreateDate()
     {
         $rawData = array(
-            \PHPExif\Mapper\FFprobe::DATETIMEORIGINAL => 'Invalid Date String'
+            FFprobe::DATETIMEORIGINAL => 'Invalid Date String'
         );
 
         $result = $this->mapper->mapRawData(
@@ -315,11 +317,11 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::normalizeComponent
+     * @covers FFprobe::normalizeComponent
      */
     public function testNormalizeComponentCorrectly()
     {
-        $reflMethod = new \ReflectionMethod('\PHPExif\Mapper\FFprobe', 'normalizeComponent');
+        $reflMethod = new \ReflectionMethod(FFprobe::class, 'normalizeComponent');
         $reflMethod->setAccessible(true);
 
         $rawData = array(
@@ -356,19 +358,19 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
         $keys = array_keys($mapped);
 
         $expected = array(
-            \PHPExif\Mapper\FFprobe::WIDTH,
-            \PHPExif\Mapper\FFprobe::MIMETYPE
+            FFprobe::WIDTH,
+            FFprobe::MIMETYPE
         );
         $this->assertEquals($expected, $keys);
     }
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::readISO6709
+     * @covers FFprobe::readISO6709
      */
     public function testreadISO6709()
     {
-        $reflMethod = new \ReflectionMethod('\PHPExif\Mapper\FFprobe', 'readISO6709');
+        $reflMethod = new \ReflectionMethod(FFprobe::class, 'readISO6709');
         $reflMethod->setAccessible(true);
 
         $testcase = array(
@@ -427,12 +429,12 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\FFprobe::convertDMStoDecimal
+     * @covers FFprobe::convertDMStoDecimal
      */
     public function testconvertDMStoDecimal()
     {
 
-        $reflMethod = new \ReflectionMethod('\PHPExif\Mapper\FFprobe', 'convertDMStoDecimal');
+        $reflMethod = new \ReflectionMethod(FFprobe::class, 'convertDMStoDecimal');
         $reflMethod->setAccessible(true);
 
         $testcase = array(

--- a/tests/PHPExif/Mapper/ImageMagickMapperTest.php
+++ b/tests/PHPExif/Mapper/ImageMagickMapperTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use PHPExif\Contracts\MapperInterface;
+use PHPExif\Mapper\ImageMagick;
 
 /**
- * @covers \PHPExif\Mapper\ImageMagick::<!public>
+ * @covers ImageMagick::<!public>
  */
 class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 {
@@ -11,7 +12,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        $this->mapper = new \PHPExif\Mapper\ImageMagick;
+        $this->mapper = new ImageMagick;
     }
 
     /**
@@ -24,7 +25,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataIgnoresFieldIfItDoesntExist()
     {
@@ -36,7 +37,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataMapsFieldsCorrectly()
     {
@@ -45,20 +46,20 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
         $map = $reflProp->getValue($this->mapper);
 
         // ignore custom formatted data stuff:
-        unset($map[\PHPExif\Mapper\ImageMagick::APERTURE]);
-        unset($map[\PHPExif\Mapper\ImageMagick::EXPOSURETIME]);
-        unset($map[\PHPExif\Mapper\ImageMagick::FOCALLENGTH]);
-        unset($map[\PHPExif\Mapper\ImageMagick::GPSLATITUDE]);
-        unset($map[\PHPExif\Mapper\ImageMagick::GPSLONGITUDE]);
-        unset($map[\PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL]);
-        unset($map[\PHPExif\Mapper\ImageMagick::ISO]);
-        unset($map[\PHPExif\Mapper\ImageMagick::LENS]);
-        unset($map[\PHPExif\Mapper\ImageMagick::WIDTH]);
-        unset($map[\PHPExif\Mapper\ImageMagick::HEIGHT]);
-        unset($map[\PHPExif\Mapper\ImageMagick::IMAGEHEIGHT_PNG]);
-        unset($map[\PHPExif\Mapper\ImageMagick::IMAGEWIDTH_PNG]);
-        unset($map[\PHPExif\Mapper\ImageMagick::CREATION_DATE]);
-        unset($map[\PHPExif\Mapper\ImageMagick::COPYRIGHT_IPTC]);
+        unset($map[ImageMagick::APERTURE]);
+        unset($map[ImageMagick::EXPOSURETIME]);
+        unset($map[ImageMagick::FOCALLENGTH]);
+        unset($map[ImageMagick::GPSLATITUDE]);
+        unset($map[ImageMagick::GPSLONGITUDE]);
+        unset($map[ImageMagick::DATETIMEORIGINAL]);
+        unset($map[ImageMagick::ISO]);
+        unset($map[ImageMagick::LENS]);
+        unset($map[ImageMagick::WIDTH]);
+        unset($map[ImageMagick::HEIGHT]);
+        unset($map[ImageMagick::IMAGEHEIGHT_PNG]);
+        unset($map[ImageMagick::IMAGEWIDTH_PNG]);
+        unset($map[ImageMagick::CREATION_DATE]);
+        unset($map[ImageMagick::COPYRIGHT_IPTC]);
 
         // create raw data
         $keys = array_unique(array_keys($map));
@@ -77,12 +78,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsAperture()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::APERTURE => '54823/32325',
+            ImageMagick::APERTURE => '54823/32325',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -92,12 +93,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDate()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::CREATION_DATE => '2015:04:01 12:11:09',
+            ImageMagick::CREATION_DATE => '2015:04:01 12:11:09',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -112,12 +113,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsDateTimeOriginal()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -132,13 +133,13 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDateAndDateTimeOriginal1()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::CREATION_DATE => '2016:04:01 12:11:09',
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            ImageMagick::CREATION_DATE => '2016:04:01 12:11:09',
+            ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -154,13 +155,13 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDateAndDateTimeOriginal2()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
-            \PHPExif\Mapper\ImageMagick::CREATION_DATE => '2016:04:01 12:11:09',
+            ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            ImageMagick::CREATION_DATE => '2016:04:01 12:11:09',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -176,20 +177,20 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDateWithTimeZone()
     {
         $data = array (
           array(
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09+0200',
+            ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09+0200',
           ),
           array(
-              \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+              ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
               'exif:OffsetTimeOriginal' => '+0200',
           ),
           array(
-              \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+              ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
               'exif:OffsetTimeOriginal' => '+0200',
           )
         );
@@ -217,12 +218,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsCreationDateWithTimeZone2()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
             'exif:OffsetTimeOriginal' => '+0200',
         );
 
@@ -246,12 +247,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectCreationDate()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::CREATION_DATE => '2015:04:01',
+            ImageMagick::CREATION_DATE => '2015:04:01',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -262,12 +263,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectDateTimeOriginal()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01',
+            ImageMagick::DATETIMEORIGINAL => '2015:04:01',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -277,12 +278,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectTimeZone()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            ImageMagick::DATETIMEORIGINAL => '2015:04:01 12:11:09',
             'exif:OffsetTimeOriginal' => '   :  ',
         );
 
@@ -298,7 +299,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
@@ -311,7 +312,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
         foreach ($rawData as $expected => $value) {
             $mapped = $this->mapper->mapRawData(array(
-                \PHPExif\Mapper\ImageMagick::EXPOSURETIME => $value,
+                ImageMagick::EXPOSURETIME => $value,
             ));
 
             $this->assertEquals($expected, reset($mapped));
@@ -320,12 +321,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsFocalLength()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::FOCALLENGTH => '15 m',
+            ImageMagick::FOCALLENGTH => '15 m',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -335,15 +336,15 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsGPSData()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\ImageMagick::GPSLATITUDE  => '40/1, 20/1, 42857/100000',
+                ImageMagick::GPSLATITUDE  => '40/1, 20/1, 42857/100000',
                 'exif:GPSLatitudeRef'                   => 'N',
-                \PHPExif\Mapper\ImageMagick::GPSLONGITUDE => '20/1, 10/1, 233333/100000',
+                ImageMagick::GPSLONGITUDE => '20/1, 10/1, 233333/100000',
                 'exif:GPSLongitudeRef'                  => 'W',
             )
         );
@@ -358,15 +359,15 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataIncorrectlyFormatedGPSData()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\ImageMagick::GPSLATITUDE  => '40/1 20/1 42857/100000',
+                ImageMagick::GPSLATITUDE  => '40/1 20/1 42857/100000',
                 'exif:GPSLatitudeRef'                     => 'N',
-                \PHPExif\Mapper\ImageMagick::GPSLONGITUDE => '20/1 10/1 233333/100000',
+                ImageMagick::GPSLONGITUDE => '20/1 10/1 233333/100000',
                 'exif:GPSLongitudeRef'                    => 'W',
             )
         );
@@ -375,15 +376,15 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsNumericGPSData()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\ImageMagick::GPSLATITUDE  => '40.333452381',
+                ImageMagick::GPSLATITUDE  => '40.333452381',
                 'exif:GPSLatitudeRef'                   => 'North',
-                \PHPExif\Mapper\ImageMagick::GPSLONGITUDE => '20.167314814',
+                ImageMagick::GPSLONGITUDE => '20.167314814',
                 'exif:GPSLongitudeRef'                  => 'West',
             )
         );
@@ -399,13 +400,13 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataOnlyLatitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\ImageMagick::GPSLATITUDE => '40.333452381',
+                ImageMagick::GPSLATITUDE => '40.333452381',
                 'exif:GPSLatitudeRef'                    => 'North',
             )
         );
@@ -415,15 +416,15 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresEmptyGPSData()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\ImageMagick::GPSLATITUDE  => '0/0, 0/0, 0/0',
+                ImageMagick::GPSLATITUDE  => '0/0, 0/0, 0/0',
                 'exif:GPSLatitudeRef'                     => '',
-                \PHPExif\Mapper\ImageMagick::GPSLONGITUDE => '0/0, 0/0, 0/0',
+                ImageMagick::GPSLONGITUDE => '0/0, 0/0, 0/0',
                 'exif:GPSLongitudeRef'                    => '',
             )
         );
@@ -435,7 +436,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
     public function testMapRawDataCorrectlyFormatsDifferentDateTimeString()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => '2014-12-15 00:12:00'
+            ImageMagick::DATETIMEORIGINAL => '2014-12-15 00:12:00'
         );
 
         $mapped = $this->mapper->mapRawData(
@@ -453,7 +454,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
     public function testMapRawDataCorrectlyIgnoresInvalidCreateDate()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::DATETIMEORIGINAL => 'Invalid Date String'
+            ImageMagick::DATETIMEORIGINAL => 'Invalid Date String'
         );
 
         $result = $this->mapper->mapRawData(
@@ -469,13 +470,13 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyAltitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\ImageMagick::GPSALTITUDE  => '122053/1000',
+                ImageMagick::GPSALTITUDE  => '122053/1000',
                 'exif:GPSAltitudeRef'                   => '0',
             )
         );
@@ -485,13 +486,13 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyNegativeAltitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\ImageMagick::GPSALTITUDE  => '122053/1000',
+                ImageMagick::GPSALTITUDE  => '122053/1000',
                 'exif:GPSAltitudeRef'                   => '1',
             )
         );
@@ -501,13 +502,13 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectAltitude()
     {
         $result = $this->mapper->mapRawData(
             array(
-                \PHPExif\Mapper\ImageMagick::GPSALTITUDE  => '0/0',
+                ImageMagick::GPSALTITUDE  => '0/0',
                 'exif:GPSAltitudeRef'                     => '0',
             )
         );
@@ -517,7 +518,7 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
         /**
          * @group mapper
-         * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+         * @covers ImageMagick::mapRawData
          */
         public function testMapRawDataCorrectlyIsoFormats()
         {
@@ -541,14 +542,14 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
         /**
          * @group mapper
-         * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+         * @covers ImageMagick::mapRawData
          */
         public function testMapRawDataCorrectlyHeightPNG()
         {
 
           $rawData = array(
               '600'  => array(
-                                \PHPExif\Mapper\ImageMagick::IMAGEHEIGHT_PNG  => '800, 600',
+                                ImageMagick::IMAGEHEIGHT_PNG  => '800, 600',
                             ),
           );
 
@@ -563,14 +564,14 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
       /**
        * @group mapper
-       * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+       * @covers ImageMagick::mapRawData
        */
       public function testMapRawDataCorrectlyWidthPNG()
       {
 
         $rawData = array(
             '800'  => array(
-                              \PHPExif\Mapper\ImageMagick::IMAGEWIDTH_PNG  => '800, 600',
+                              ImageMagick::IMAGEWIDTH_PNG  => '800, 600',
                           ),
         );
 
@@ -583,11 +584,11 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
       /**
        * @group mapper
-       * @covers \PHPExif\Mapper\ImageMagick::normalizeComponent
+       * @covers ImageMagick::normalizeComponent
        */
       public function testNormalizeComponentCorrectly()
       {
-          $reflMethod = new \ReflectionMethod('\PHPExif\Mapper\ImageMagick', 'normalizeComponent');
+          $reflMethod = new \ReflectionMethod(ImageMagick::class, 'normalizeComponent');
           $reflMethod->setAccessible(true);
 
           $rawData = array(
@@ -611,12 +612,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyKeywords()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::KEYWORDS => 'Keyword_1 Keyword_2',
+            ImageMagick::KEYWORDS => 'Keyword_1 Keyword_2',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -629,12 +630,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyKeywordsAndSubject()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::KEYWORDS => array('Keyword_1', 'Keyword_2'),
+            ImageMagick::KEYWORDS => array('Keyword_1', 'Keyword_2'),
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -647,12 +648,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsXResolution()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::XRESOLUTION => '1500/300',
+            ImageMagick::XRESOLUTION => '1500/300',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -662,12 +663,12 @@ class ImageMagickMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\ImageMagick::mapRawData
+     * @covers ImageMagick::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsYResolution()
     {
         $rawData = array(
-            \PHPExif\Mapper\ImageMagick::YRESOLUTION => '1500/300',
+            ImageMagick::YRESOLUTION => '1500/300',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);

--- a/tests/PHPExif/Mapper/NativeMapperTest.php
+++ b/tests/PHPExif/Mapper/NativeMapperTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use PHPExif\Contracts\MapperInterface;
+use PHPExif\Mapper\Native;
 
 /**
- * @covers \PHPExif\Mapper\Native::<!public>
+ * @covers Native::<!public>
  */
 class NativeMapperTest extends \PHPUnit\Framework\TestCase
 {
@@ -11,7 +12,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        $this->mapper = new \PHPExif\Mapper\Native;
+        $this->mapper = new Native;
     }
 
     /**
@@ -24,7 +25,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataIgnoresFieldIfItDoesntExist()
     {
@@ -36,7 +37,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataMapsFieldsCorrectly()
     {
@@ -45,21 +46,21 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
         $map = $reflProp->getValue($this->mapper);
 
         // ignore custom formatted data stuff:
-        unset($map[\PHPExif\Mapper\Native::DATETIMEORIGINAL]);
-        unset($map[\PHPExif\Mapper\Native::EXPOSURETIME]);
-        unset($map[\PHPExif\Mapper\Native::FOCALLENGTH]);
-        unset($map[\PHPExif\Mapper\Native::XRESOLUTION]);
-        unset($map[\PHPExif\Mapper\Native::YRESOLUTION]);
-        unset($map[\PHPExif\Mapper\Native::GPSLATITUDE]);
-        unset($map[\PHPExif\Mapper\Native::GPSLONGITUDE]);
-        unset($map[\PHPExif\Mapper\Native::FRAMERATE]);
-        unset($map[\PHPExif\Mapper\Native::DURATION]);
-        unset($map[\PHPExif\Mapper\Native::CITY]);
-        unset($map[\PHPExif\Mapper\Native::SUBLOCATION]);
-        unset($map[\PHPExif\Mapper\Native::STATE]);
-        unset($map[\PHPExif\Mapper\Native::COUNTRY]);
-        unset($map[\PHPExif\Mapper\Native::LENS_LR]);
-        unset($map[\PHPExif\Mapper\Native::LENS_TYPE]);
+        unset($map[Native::DATETIMEORIGINAL]);
+        unset($map[Native::EXPOSURETIME]);
+        unset($map[Native::FOCALLENGTH]);
+        unset($map[Native::XRESOLUTION]);
+        unset($map[Native::YRESOLUTION]);
+        unset($map[Native::GPSLATITUDE]);
+        unset($map[Native::GPSLONGITUDE]);
+        unset($map[Native::FRAMERATE]);
+        unset($map[Native::DURATION]);
+        unset($map[Native::CITY]);
+        unset($map[Native::SUBLOCATION]);
+        unset($map[Native::STATE]);
+        unset($map[Native::COUNTRY]);
+        unset($map[Native::LENS_LR]);
+        unset($map[Native::LENS_TYPE]);
 
         // create raw data
         $keys = array_keys($map);
@@ -79,12 +80,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsDateTimeOriginal()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            Native::DATETIMEORIGINAL => '2015:04:01 12:11:09',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -100,12 +101,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
         /**
          * @group mapper
-         * @covers \PHPExif\Mapper\Native::mapRawData
+         * @covers Native::mapRawData
          */
         public function testMapRawDataCorrectlyFormatsCreationDateWithTimeZone()
         {
             $rawData = array(
-                \PHPExif\Mapper\Native::DATETIMEORIGINAL => '2015:04:01 12:11:09+0200',
+                Native::DATETIMEORIGINAL => '2015:04:01 12:11:09+0200',
             );
 
             $mapped = $this->mapper->mapRawData($rawData);
@@ -128,12 +129,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
         /**
          * @group mapper
-         * @covers \PHPExif\Mapper\Native::mapRawData
+         * @covers Native::mapRawData
          */
         public function testMapRawDataCorrectlyFormatsCreationDateWithTimeZone2()
         {
             $rawData = array(
-                \PHPExif\Mapper\Native::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+                Native::DATETIMEORIGINAL => '2015:04:01 12:11:09',
                 'UndefinedTag:0x9011' => '+0200',
             );
 
@@ -157,12 +158,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectDateTimeOriginal()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::DATETIMEORIGINAL => '2015:04:01',
+            Native::DATETIMEORIGINAL => '2015:04:01',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -172,12 +173,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectTimeZone()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::DATETIMEORIGINAL => '2015:04:01 12:11:09',
+            Native::DATETIMEORIGINAL => '2015:04:01 12:11:09',
             'UndefinedTag:0x9011' => '   :  ',
         );
 
@@ -193,7 +194,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsExposureTime()
     {
@@ -206,7 +207,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
         foreach ($rawData as $expected => $value) {
             $mapped = $this->mapper->mapRawData(array(
-                \PHPExif\Mapper\Native::EXPOSURETIME => $value,
+                Native::EXPOSURETIME => $value,
             ));
 
             $this->assertEquals($expected, reset($mapped));
@@ -215,12 +216,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsFocalLength()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::FOCALLENGTH => '30/5',
+            Native::FOCALLENGTH => '30/5',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -230,12 +231,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsFocalLengthDivisionByZero()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::FOCALLENGTH => '1/0',
+            Native::FOCALLENGTH => '1/0',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -245,12 +246,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsXResolution()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::XRESOLUTION => '1500/300',
+            Native::XRESOLUTION => '1500/300',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -260,12 +261,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsYResolution()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::YRESOLUTION => '1500/300',
+            Native::YRESOLUTION => '1500/300',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -275,35 +276,35 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataFlattensRawDataWithSections()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::SECTION_COMPUTED => array(
-                \PHPExif\Mapper\Native::TITLE => 'Hello',
+            Native::SECTION_COMPUTED => array(
+                Native::TITLE => 'Hello',
             ),
-            \PHPExif\Mapper\Native::HEADLINE => 'Headline',
+            Native::HEADLINE => 'Headline',
         );
         $mapped = $this->mapper->mapRawData($rawData);
         $this->assertCount(2, $mapped);
         $keys = array_keys($mapped);
 
         $expected = array(
-            \PHPExif\Mapper\Native::TITLE,
-            \PHPExif\Mapper\Native::HEADLINE
+            Native::TITLE,
+            Native::HEADLINE
         );
         $this->assertEquals($expected, $keys);
     }
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataMatchesFieldsWithoutCaseSensibilityOnFirstLetter()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::ORIENTATION => 'Portrait',
+            Native::ORIENTATION => 'Portrait',
             'Copyright' => 'Acme',
         );
         $mapped = $this->mapper->mapRawData($rawData);
@@ -311,15 +312,15 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
         $keys = array_keys($mapped);
 
         $expected = array(
-            \PHPExif\Mapper\Native::ORIENTATION,
-            \PHPExif\Mapper\Native::COPYRIGHT
+            Native::ORIENTATION,
+            Native::COPYRIGHT
         );
         $this->assertEquals($expected, $keys);
     }
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsGPSData()
     {
@@ -352,7 +353,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresEmptyGPSData()
     {
@@ -370,7 +371,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyFormatsAltitudeData()
     {
@@ -393,7 +394,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyIgnoresIncorrectAltitude()
     {
@@ -409,7 +410,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
     public function testMapRawDataCorrectlyFormatsDifferentDateTimeString()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::DATETIMEORIGINAL => '2014-12-15 00:12:00'
+            Native::DATETIMEORIGINAL => '2014-12-15 00:12:00'
         );
 
         $mapped = $this->mapper->mapRawData(
@@ -427,7 +428,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
     public function testMapRawDataCorrectlyIgnoresInvalidCreateDate()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::DATETIMEORIGINAL => 'Invalid Date String'
+            Native::DATETIMEORIGINAL => 'Invalid Date String'
         );
 
         $result = $this->mapper->mapRawData(
@@ -443,11 +444,11 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::normalizeComponent
+     * @covers Native::normalizeComponent
      */
     public function testNormalizeComponentCorrectly()
     {
-        $reflMethod = new \ReflectionMethod('\PHPExif\Mapper\Native', 'normalizeComponent');
+        $reflMethod = new \ReflectionMethod(Native::class, 'normalizeComponent');
         $reflMethod->setAccessible(true);
 
         $rawData = array(
@@ -470,7 +471,7 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyIsoFormats()
     {
@@ -494,26 +495,26 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyLensData()
     {
         $data = array (
             array(
-                \PHPExif\Mapper\Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
             ),
             array(
-                \PHPExif\Mapper\Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
-                \PHPExif\Mapper\Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
-                \PHPExif\Mapper\Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
             ),
             array(
-                \PHPExif\Mapper\Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
-                \PHPExif\Mapper\Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
             ),
             array(
-                \PHPExif\Mapper\Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
-                \PHPExif\Mapper\Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
+                Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                Native::LENS => 'LEICA DG 12-60/F2.8-4.0',
             )
         );
 
@@ -529,16 +530,16 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyLensData2()
     {
         $data = array (
             array(
-                \PHPExif\Mapper\Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                Native::LENS_LR => 'LUMIX G VARIO 12-32/F3.5-5.6',
             ),
             array(
-                \PHPExif\Mapper\Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
+                Native::LENS_TYPE => 'LUMIX G VARIO 12-32/F3.5-5.6',
             )
         );
 
@@ -554,12 +555,12 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyKeywords()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::KEYWORDS => 'Keyword_1 Keyword_2',
+            Native::KEYWORDS => 'Keyword_1 Keyword_2',
         );
 
         $mapped = $this->mapper->mapRawData($rawData);
@@ -572,13 +573,13 @@ class NativeMapperTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group mapper
-     * @covers \PHPExif\Mapper\Native::mapRawData
+     * @covers Native::mapRawData
      */
     public function testMapRawDataCorrectlyKeywordsAndSubject()
     {
         $rawData = array(
-            \PHPExif\Mapper\Native::KEYWORDS => array('Keyword_1', 'Keyword_2'),
-            \PHPExif\Mapper\Native::SUBJECT => array('Keyword_1', 'Keyword_3'),
+            Native::KEYWORDS => array('Keyword_1', 'Keyword_2'),
+            Native::SUBJECT => array('Keyword_1', 'Keyword_3'),
         );
 
         $mapped = $this->mapper->mapRawData($rawData);

--- a/tests/PHPExif/Reader/ReaderTest.php
+++ b/tests/PHPExif/Reader/ReaderTest.php
@@ -1,5 +1,11 @@
 <?php
 
+use PHPExif\Adapter\Exiftool;
+use PHPExif\Adapter\FFprobe;
+use PHPExif\Adapter\ImageMagick;
+use PHPExif\Adapter\Native;
+use PHPExif\Contracts\AdapterInterface;
+use PHPExif\Exif;
 use PHPExif\Reader\Reader;
 
 /**
@@ -19,7 +25,7 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
     public function setUp() : void
     {
         /** @var \PHPExif\Contracts\AdapterInterface */
-        $adapter = $this->getMockBuilder('\PHPExif\Contracts\AdapterInterface')->getMockForAbstractClass();
+        $adapter = $this->getMockBuilder(AdapterInterface::class)->getMockForAbstractClass();
         $this->reader = new \PHPExif\Reader\Reader($adapter);
     }
 
@@ -30,8 +36,8 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
     public function testConstructorWithAdapter()
     {
         /** @var \PHPExif\Contracts\AdapterInterface */
-        $mock = $this->getMockBuilder('\PHPExif\Contracts\AdapterInterface')->getMockForAbstractClass();
-        $reflProperty = new \ReflectionProperty('\PHPExif\Reader\Reader', 'adapter');
+        $mock = $this->getMockBuilder(AdapterInterface::class)->getMockForAbstractClass();
+        $reflProperty = new \ReflectionProperty(Reader::class, 'adapter');
         $reflProperty->setAccessible(true);
 
         $reader = new \PHPExif\Reader\Reader($mock);
@@ -45,9 +51,9 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetAdapterFromProperty()
     {
-        $mock = $this->getMockBuilder('\PHPExif\Contracts\AdapterInterface')->getMockForAbstractClass();
+        $mock = $this->getMockBuilder(AdapterInterface::class)->getMockForAbstractClass();
 
-        $reflProperty = new \ReflectionProperty('\PHPExif\Reader\Reader', 'adapter');
+        $reflProperty = new \ReflectionProperty(Reader::class, 'adapter');
         $reflProperty->setAccessible(true);
         $reflProperty->setValue($this->reader, $mock);
 
@@ -62,7 +68,7 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
     public function testGetAdapterThrowsExceptionWhenNoAdapterIsSet()
     {
         $this->expectException('\PHPExif\Adapter\NoAdapterException');
-        $reflProperty = new \ReflectionProperty('\PHPExif\Reader\Reader', 'adapter');
+        $reflProperty = new \ReflectionProperty(Reader::class, 'adapter');
         $reflProperty->setAccessible(true);
         $reflProperty->setValue($this->reader, null);
 
@@ -75,10 +81,10 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetExifPassedToAdapter()
     {
-        $adapter = $this->getMockBuilder('\PHPExif\Contracts\AdapterInterface')->getMockForAbstractClass();
+        $adapter = $this->getMockBuilder(AdapterInterface::class)->getMockForAbstractClass();
         $adapter->expects($this->once())->method('getExifFromFile');
 
-        $reflProperty = new \ReflectionProperty('\PHPExif\Reader\Reader', 'adapter');
+        $reflProperty = new \ReflectionProperty(Reader::class, 'adapter');
         $reflProperty->setAccessible(true);
         $reflProperty->setValue($this->reader, $adapter);
 
@@ -103,7 +109,7 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
     {
         $reader = \PHPExif\Reader\Reader::factory(\PHPExif\Enum\ReaderType::NATIVE);
 
-        $this->assertInstanceOf('\PHPExif\Reader\Reader', $reader);
+        $this->assertInstanceOf(Reader::class, $reader);
     }
 
     /**
@@ -113,12 +119,12 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
     public function testFactoryAdapterTypeNative()
     {
         $reader = \PHPExif\Reader\Reader::factory(\PHPExif\Enum\ReaderType::NATIVE);
-        $reflProperty = new \ReflectionProperty('\PHPExif\Reader\Reader', 'adapter');
+        $reflProperty = new \ReflectionProperty(Reader::class, 'adapter');
         $reflProperty->setAccessible(true);
 
         $adapter = $reflProperty->getValue($reader);
 
-        $this->assertInstanceOf('\PHPExif\Adapter\Native', $adapter);
+        $this->assertInstanceOf(Native::class, $adapter);
     }
 
     /**
@@ -128,12 +134,12 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
     public function testFactoryAdapterTypeExiftool()
     {
         $reader = \PHPExif\Reader\Reader::factory(\PHPExif\Enum\ReaderType::EXIFTOOL);
-        $reflProperty = new \ReflectionProperty('\PHPExif\Reader\Reader', 'adapter');
+        $reflProperty = new \ReflectionProperty(Reader::class, 'adapter');
         $reflProperty->setAccessible(true);
 
         $adapter = $reflProperty->getValue($reader);
 
-        $this->assertInstanceOf('\PHPExif\Adapter\Exiftool', $adapter);
+        $this->assertInstanceOf(Exiftool::class, $adapter);
     }
 
     /**
@@ -143,12 +149,12 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
     public function testFactoryAdapterTypeFFprobe()
     {
         $reader = \PHPExif\Reader\Reader::factory(\PHPExif\Enum\ReaderType::FFPROBE);
-        $reflProperty = new \ReflectionProperty('\PHPExif\Reader\Reader', 'adapter');
+        $reflProperty = new \ReflectionProperty(Reader::class, 'adapter');
         $reflProperty->setAccessible(true);
 
         $adapter = $reflProperty->getValue($reader);
 
-        $this->assertInstanceOf('\PHPExif\Adapter\FFprobe', $adapter);
+        $this->assertInstanceOf(FFprobe::class, $adapter);
     }
 
 
@@ -159,12 +165,12 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
     public function testFactoryAdapterTypeImageMagick()
     {
         $reader = \PHPExif\Reader\Reader::factory(\PHPExif\Enum\ReaderType::IMAGICK);
-        $reflProperty = new \ReflectionProperty('\PHPExif\Reader\Reader', 'adapter');
+        $reflProperty = new \ReflectionProperty(Reader::class, 'adapter');
         $reflProperty->setAccessible(true);
 
         $adapter = $reflProperty->getValue($reader);
 
-        $this->assertInstanceOf('\PHPExif\Adapter\ImageMagick', $adapter);
+        $this->assertInstanceOf(ImageMagick::class, $adapter);
     }
 
     /**
@@ -173,13 +179,14 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetExifFromFileCallsReadMethod()
     {
-        $mock = $this->getMockBuilder('\\PHPExif\\Reader\\Reader')
+        /** @var MockObject<Reader> $mock */
+        $mock = $this->getMockBuilder(Reader::class)
             ->onlyMethods(array('read'))
             ->disableOriginalConstructor()
             ->getMock();
 
         $expected = '/foo/bar/baz';
-        $expectedResult = 'test';
+        $expectedResult = new Exif([]);
 
         $mock->expects($this->once())
             ->method('read')


### PR DESCRIPTION
As noted in https://github.com/LycheeOrg/Lychee/issues/1729 the reader always return an Exif object. Hence the other return types are not needed. This aims to clarify this situation in the contract.