### PR TITLE
Fix FFProbe keywords as String

### DIFF
--- a/lib/PHPExif/Mapper/FFprobe.php
+++ b/lib/PHPExif/Mapper/FFprobe.php
@@ -163,6 +163,13 @@ class FFprobe extends AbstractMapper
                     $mappedData[Exif::LONGITUDE] = $location_data['longitude'];
                     $mappedData[Exif::ALTITUDE]  = $location_data['altitude'];
                     continue 2;
+                case self::QUICKTIME_KEYWORDS:
+                    if (is_string($value)) {
+                        $mappedData[Exif::KEYWORDS] = explode(",", $value);
+                    } else {
+                        $mappedData[Exif::KEYWORDS] = $value;
+                    }
+                    continue 2;
             }
 
             // set end result

--- a/tests/PHPExif/Mapper/FFprobeMapperTest.php
+++ b/tests/PHPExif/Mapper/FFprobeMapperTest.php
@@ -482,4 +482,58 @@ class FFprobeMapperTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals($expected, $result);
         }
     }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     */
+    public function testMapRawDataCorrectlyKeywords()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\FFprobe::QUICKTIME_KEYWORDS => 'Keyword_1 Keyword_2',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(
+            ['Keyword_1 Keyword_2'],
+            reset($mapped)
+        );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     */
+    public function testMapRawDataCorrectlySplitKeywords()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\FFprobe::QUICKTIME_KEYWORDS => 'Keyword_1,Keyword_2',
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(
+            ['Keyword_1', 'Keyword_2'],
+            reset($mapped)
+        );
+    }
+
+    /**
+     * @group mapper
+     * @covers \PHPExif\Mapper\FFprobe::mapRawData
+     */
+    public function testMapRawDataCorrectlyArrayKeywords()
+    {
+        $rawData = array(
+            \PHPExif\Mapper\FFprobe::QUICKTIME_KEYWORDS => array('Keyword_1', 'Keyword_2'),
+        );
+
+        $mapped = $this->mapper->mapRawData($rawData);
+
+        $this->assertEquals(
+            ['Keyword_1', 'Keyword_2'],
+            reset($mapped)
+        );
+    }
 }


### PR DESCRIPTION
`ffprobe` version 4.4.2 returns a string for tags like `com.apple.quicktime.keywords`:

example:
```
    "format": {
        ...
        "tags": {
            ...
            "com.apple.quicktime.keywords": "keyword"
        }
    }
```

If the value is a string, this patch splits on a comma multiple keywords.