### PR TITLE
Fix GPS extraction for ImageMagick string format

### DIFF
--- a/lib/PHPExif/Mapper/ImageMagick.php
+++ b/lib/PHPExif/Mapper/ImageMagick.php
@@ -274,7 +274,7 @@ class ImageMagick extends AbstractMapper
         if (is_numeric($coordinates) === true) {
             return ((float) $coordinates);
         } else {
-            $m = '!^([0-9]+\/[1-9][0-9]*)(?:, ([0-9]+\/[1-9][0-9]*))?(?:, ([0-9]+\/[1-9][0-9]*))?$!';
+            $m = '!^([0-9]+\/[1-9][0-9]*)(?:,\s*([0-9]+\/[1-9][0-9]*))?(?:,\s*([0-9]+\/[1-9][0-9]*))?$!';
             if (preg_match($m, $coordinates, $matches) === 0) {
                 return false;
             }

--- a/tests/PHPExif/ExifTest.php
+++ b/tests/PHPExif/ExifTest.php
@@ -741,10 +741,10 @@ class ExifTest extends \PHPUnit\Framework\TestCase
                     'Adapter difference detected native/exiftool in method "' . $name . '" on image "' . basename($file) . '"'
                 );
 
-                if (in_array(basename($file), ['dsc_0003.jpg', 'mongolia.jpeg'], true)
+                if (in_array(basename($file), ['dsc_0003.jpg'], true)
                     && in_array($name, ['getGPS', 'getLongitude', 'getLatitude'], true)
-                    && in_array($result_native, ['1,1', 1.0, '46.898392,102.76863098333', 46.898392, 102.768630983333], true)
-                    && $result_imagemagick === false) {
+                    && in_array($result_native, ['1,1', 1.0], true)
+                    && in_array($result_imagemagick, ['1.017917240991,1.075044832787', 1.017917240991, 1.075044832787], true)) {
                     // Skip that test...
                     // Something is going wrong here, no clue what.
                     // Suspect it is on php-imagick side.


### PR DESCRIPTION
Updates the GPS coordinate regex to account for variations in whitespace.

On my system ImageMagick does not output any whitespace after the commas, making extraction fail with current regex:

```bash
$ identify -format "%[EXIF:GPSLatitude]\n" tests/files/mongolia.jpeg 
46/1,53903520/1000000,0/1
```

I assume this is version dependent but I haven't investigated any further.
```bash
$ identify --version
Version: ImageMagick 6.9.12-98 Q16 x86_64 18038 https://legacy.imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC Modules OpenMP(4.5) 
Delegates (built-in): bzlib djvu fftw fontconfig freetype heic jbig jng jp2 jpeg lcms lqr ltdl lzma openexr pangocairo png raw tiff webp wmf x xml zlib
```